### PR TITLE
Feature/issue #70

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
    actable
-   validates:email,:email => true,
+   validates :email,:email => true,
             :uniqueness => true,
             :presence => true
    validates_presence_of :first_name

--- a/db/migrate/20151026060621_agency_people_job_seekers_join_table.rb
+++ b/db/migrate/20151026060621_agency_people_job_seekers_join_table.rb
@@ -1,9 +1,9 @@
 class AgencyPeopleJobSeekersJoinTable < ActiveRecord::Migration
   	def change
-    	create_table :agencies_seekers, id: false do |t|
+    	create_table :seekers_agency_people, id: false do |t|
     		t.integer :agency_person_id 
     		t.integer :job_seeker_id 
     end
-   	 add_index :agencies_seekers, [:agency_person_id, :job_seeker_id]
+   	 # add_index :seekers_agency_people, [:agency_person_id, :job_seeker_id]
   end
 end

--- a/db/migrate/20151026060621_agency_people_job_seekers_join_table.rb
+++ b/db/migrate/20151026060621_agency_people_job_seekers_join_table.rb
@@ -1,0 +1,9 @@
+class AgencyPeopleJobSeekersJoinTable < ActiveRecord::Migration
+  	def change
+    	create_table :agencies_seekers, id: false do |t|
+    		t.integer :agency_person_id 
+    		t.integer :job_seeker_id 
+    end
+   	 add_index :agencies_seekers, [:agency_person_id, :job_seeker_id]
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :user do
     email 'johndoe@place.com'
-first_name 'John'
-last_name "Doe"
-phone '(123) 123 1234'
+    first_name 'John'
+   last_name "Doe"
+   phone '(123) 123 1234'
   end
 
 end


### PR DESCRIPTION
renamed table name to seeker_agency_people,
Still can not allow me to create the table if I wanted to index the columns so commented for now the index part. This is what says:
Index name 'index_seekers_agency_people_on_agency_person_id_and_job_seeker_id' on table 'seekers_agency_people' is too long; the limit is 62 characters