### PR TITLE
closes AgileVentures/MetPlus_tracker#140

### DIFF
--- a/features/agency_admin.feature
+++ b/features/agency_admin.feature
@@ -115,4 +115,26 @@ Scenario: error for edit branch
   Then I should see "2 errors prevented this record from being saved:"
   And I should see "Code has already been taken"
   And I should see "Address zipcode should be in form of 12345 or 12345-1234"
+  
+Scenario: new agency branch
+  Given I am logged in as agency admin
+  And I click the "Admin" link
+  And I click the "Create Branch" button
+  Then I fill in "Branch Code" with "004"
+  And I fill in "Street" with "10 Ford Way"
+  And I fill in "City" with "Detroit"
+  And I fill in "Zipcode" with "48208"
+  And I click the "Create" button
+  Then I should see "Branch was successfully created."
+  And I should see "004"
+
+@selenium
+Scenario: delete agency branch
+  Given I am logged in as agency admin
+  And I click the "Admin" link
+  And I click the "003" link
+  Then I click the "Delete Branch" button
+  And I confirm the popup dialog
+  Then I should see "Branch '003' deleted."
+  
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -58,3 +58,15 @@ end
 And(/^show me the page$/) do
   save_and_open_page
 end
+
+When(/^I confirm the popup dialog$/) do
+  page.accept_confirm # clicks the 'OK' button
+  
+  # If wish to confirm the text of the dialog box, this will work:
+  #   box = page.driver.browser.switch_to.alert
+  #   expect(box.text).to eq '<expected text here .....'
+  # The box can be accepted:
+  #   box.accept
+  # Or dismissed:
+  #   box.dismiss
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -80,7 +80,7 @@ else
     #debug:       true
     )
   end
-  # Capybara.default_driver    = :poltergeist
+  #Capybara.default_driver    = :poltergeist
   Capybara.javascript_driver = :poltergeist
 end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,12 @@
+Before('@selenium') do
+  # This hook should be used for tests that include a modal dialog -
+  # Poltergeist does not handle those cleanly.
+  # This will run all @selenium tests in Firefox (non-headless).
+  # If headless is desired then probably need to use gem selenium-webkit
+  Capybara.javascript_driver = :selenium
+end
+
+After('@selenium') do
+  Capybara.reset_sessions!
+  Capybara.javascript_driver = :poltergeist
+end


### PR DESCRIPTION
Added cucumber hook @selenium - use that for tests that require response to a modal dialog (such as "Delete Agency Branch?").  This will use Selenium as the javascript driver.  (The default javascript driver is Poltergeist, but that driver has limitations with respect to modal dialog interaction).

Note that Selenium is *not* headless - it will cause the test to be run with a "head" in Firefox.