### PR TITLE
Closes AgileVentures/MetPlus_tracker#180

### DIFF
--- a/app/views/company_registrations/_form.html.haml
+++ b/app/views/company_registrations/_form.html.haml
@@ -86,4 +86,4 @@
     .col-sm-2.col-sm-offset-2
       = submit_tag submit, method: :post, class: 'btn btn-primary'
     .col-sm-2.col-sm-offset-2
-      = link_to 'Cancel', root_path, class: 'btn btn-danger'
+      = link_to 'Cancel', agency_admin_home_path, class: 'btn btn-danger'

--- a/features/company_registration.feature
+++ b/features/company_registration.feature
@@ -114,3 +114,34 @@ Scenario: duplicate EIN for Company
   | Password Confirmation          | qwerty123           |
   And I click the "Create" button
   Then I should see "Ein has already been registered"
+
+Scenario: edit Company Registration: change contact email
+  Given I am logged in as agency admin
+  And a clear email queue
+  And I click the "Admin" link
+  Then I click the "Widgets, Inc." link
+  Then I should see "Pending Registration"
+  And I click the "Edit Registration" button
+  And I should see "Edit Company Registration"
+  Then I fill in "Company Name" with "Gizmos, Inc."
+  And I fill in "Contact Email" with "hughjobs@gizmos.com"
+  And I click the "Update" button
+  Then I should see "Registration was successfully updated."
+  Then "hughjobs@widgets.com" should have no emails
+  And "hughjobs@gizmos.com" should receive 1 email with subject "Pending approval"
+  Then "hughjobs@gizmos.com" opens the email
+  And they should see "Thank you for registering Gizmos, Inc. in PETS." in the email body
+
+Scenario: edit Company Registration: change contact password
+  Given I am logged in as agency admin
+  And a clear email queue
+  And I click the "Admin" link
+  Then I click the "Widgets, Inc." link
+  Then I should see "Pending Registration"
+  And I click the "Edit Registration" button
+  And I should see "Edit Company Registration"
+  Then I fill in "Password" with "abcd1234"
+  Then I fill in "Password Confirmation" with "abcd1234"
+  And I click the "Update" button
+  Then I should see "Registration was successfully updated."
+  Then "hughjobs@widgets.com" should have no emails 


### PR DESCRIPTION
The update action has these problems:

1. It was not allowing the email address for the company contact to be changed, and was failing silently
2. It was causing the Device confirmable module to send an "email address confirmation" email to the new email address.
This behavior is expected for a typical email address change by a user, since we have configured Devise to require both new and changed email addresses to be confirmed (via an email with a link that passes back a token to confirm the address).  (this is actually the root cause of the first problem noted above - Devise needs to confirm a changed email address before making the change to the User object).

However, we do not want confirmation behavior for a company contact email - while the company is in "pending approval" stage - because the company contact is not yet a bona fide user of PETS.