### PR TITLE
Closes AgileVentures/MetPlus_tracker#215

### DIFF
--- a/app/views/agency_admin/home.html.haml
+++ b/app/views/agency_admin/home.html.haml
@@ -12,66 +12,55 @@
   .col-sm-3
     %h4 Agency Branches
 
-  .col-sm-9
-    - if @branches.empty?
-      %h5 There are no branches.
-    - else
-      = render 'branches/branches'
-
-.row
   - if @branches.empty?
-    .col-sm-2.col-sm-offset-10.table_action_button
-      = button_to 'Add Branch', new_agency_branch_path(@agency.id), |
-          method: :get, class: 'btn btn-primary btn-sm pull-right'  |
+    .col-sm-3
+      %h5 There are no branches.
   - else
+    .col-sm-9
+      = render 'branches/branches'
+    .clearfix
     .col-sm-3.col-sm-offset-3
       %a(id='toggle_branches' href='#branches_table' class='text-danger')
         Hide Branches
-    .col-sm-2.col-sm-offset-4.table_action_button
-      = button_to 'Add Branch', new_agency_branch_path(@agency.id), |
-          method: :get, class: 'btn btn-primary btn-sm pull-right'  |
+
+  .col-sm-3.col-sm-offset-3.table_action_button
+    = button_to 'Add Branch', new_agency_branch_path(@agency.id), |
+        method: :get, class: 'btn btn-primary btn-sm pull-right'  |
 
 .row
   %hr
   .col-sm-3
     %h4 Agency Personnel
 
-  .col-sm-9
-    - if @agency_people.empty?
-      %h5 There are no agency people.
-    - else
-      = render partial: 'agency_people/agency_people'
-
-.row
   - if @agency_people.empty?
-    .col-sm-2.col-sm-offset-10.table_action_button
-      = link_to 'Invite Person',                                    |
-          new_user_invitation_path(person_type: 'AgencyPerson',     |
-                   org_id: @agency.id),                             |
-          method: :get, class: 'btn btn-primary btn-sm pull-right'  |
+    .col-sm-3
+      %h5 There are no agency people.
   - else
+    .col-sm-9
+      = render 'agency_people/agency_people'
+    .clearfix
     .col-sm-3.col-sm-offset-3
       %a(id='toggle_people' href='#people_table' class='text-danger')
         Hide People
-    .col-sm-2.col-sm-offset-4.table_action_button
-      = link_to 'Invite Person',                                    |
-          new_user_invitation_path(person_type: 'AgencyPerson',     |
-                   org_id: @agency.id),                             |
-          method: :get, class: 'btn btn-primary btn-sm pull-right'  |
+
+  .col-sm-3.col-sm-offset-3.table_action_button
+    = link_to 'Invite Person',                                    |
+        new_user_invitation_path(person_type: 'AgencyPerson',     |
+                 org_id: @agency.id),                             |
+        method: :get, class: 'btn btn-primary btn-sm pull-right'  |
 
 .row
   %hr
   .col-sm-3
     %h4 Companies
 
-  .col-sm-9
-    - if @companies.empty?
+  - if @companies.empty?
+    .col-sm-3
       %h5 There are no companies.
-    - else
-      = render partial: 'companies/companies'
-
-.row
-  - if not @companies.empty?
+  - else
+    .col-sm-9
+      = render 'companies/companies'
+    .clearfix
     .col-sm-3.col-sm-offset-3
       %a(id='toggle_companies' href='#companies_table' class='text-danger')
         Hide Companies

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -118,11 +118,13 @@ if Rails.env.development? # || Rails.env.staging?
     email =Faker::Internet.email
     website = Faker::Internet.url
     name = Faker::Company.name
-    Company.create!(ein: ein,
+    cmp = Company.new(ein: ein,
                     phone: phone,
                     email: email,
-                    website: website,
-                    name: name)
+                  website: website,
+                     name: name)
+    cmp.agencies << agency
+    cmp.save!
   end
 
   companies = Company.all.to_a
@@ -181,8 +183,7 @@ if Rails.env.development? # || Rails.env.staging?
     shift = ["Day", "Evening", "Morning"][r.rand(3)]
     fulltime =  [false, true][r.rand(2)]
     jobId = ((1..9).to_a + ('A'..'Z').to_a).shuffle[0..7].join
-
-    Job.create!(title: title,
+    Job.create(title: title,
                description: description,
                shift: shift,
                company_job_id: jobId ,


### PR DESCRIPTION
The agency admin home page view had duplicate code for display of branches, people and companies.  This has been refactored to remove the duplicate code.

Also, made minor changes to seeds.rb:
1) Added agency association to created companies so that these companies will appear in the admin home page,
2) Changed *Job.create!* to *Job.create* to that create failure does not cause rake to abort.  (it is not necessary that all company-create actions within that loop succeed)