### PR TITLE
Closes AgileVentures/MetPlus_tracker#120

### DIFF
--- a/app/controllers/job_seekers_controller.rb
+++ b/app/controllers/job_seekers_controller.rb
@@ -21,6 +21,7 @@ class JobSeekersController < ApplicationController
         unless resume.save
           models_saved = false
           @jobseeker.destroy
+          @jobseeker.errors.messages.merge! resume.errors.messages
         end
       end
     end

--- a/app/controllers/job_seekers_controller.rb
+++ b/app/controllers/job_seekers_controller.rb
@@ -5,8 +5,27 @@ class JobSeekersController < ApplicationController
   end
 
   def create
+    jobseeker_params = form_params
+    dispatch_file    = jobseeker_params.delete 'resume'
+
     @jobseeker = JobSeeker.new(jobseeker_params)
-    if @jobseeker.save
+    models_saved = @jobseeker.save
+
+    if models_saved
+      if dispatch_file          # If there is a résumé, try to save that
+        tempfile = dispatch_file.tempfile
+        filename = dispatch_file.original_filename
+
+        resume = Resume.new(file: tempfile, file_name: filename,
+                            job_seeker_id: @jobseeker.id)
+        unless resume.save
+          models_saved = false
+          @jobseeker.destroy
+        end
+      end
+    end
+
+    if models_saved
       flash[:notice] = "A message with a confirmation and link has been sent to your email address. " +
                        "Please follow the link to activate your account."
       redirect_to root_path
@@ -14,7 +33,6 @@ class JobSeekersController < ApplicationController
       @model_errors = @jobseeker.errors
       render 'new'
     end
-
   end
 
   def edit
@@ -24,7 +42,7 @@ class JobSeekersController < ApplicationController
   def update
     @jobseeker = JobSeeker.find(params[:id])
 
-    person_params = jobseeker_params
+    person_params = form_params
     if person_params['password'].to_s.length == 0
        person_params.delete('password')
        person_params.delete('password_confirmation')
@@ -63,7 +81,7 @@ class JobSeekersController < ApplicationController
   end
 
   private
-   def jobseeker_params
+   def form_params
      params.require(:job_seeker).permit(:first_name,
             :last_name, :email, :phone,
             :password,
@@ -71,6 +89,5 @@ class JobSeekersController < ApplicationController
             :year_of_birth,
             :job_seeker_status_id,
             :resume)
-
    end
 end

--- a/app/models/job_seeker.rb
+++ b/app/models/job_seeker.rb
@@ -7,7 +7,7 @@ class JobSeeker < ActiveRecord::Base
   has_many   :agency_relations
   has_many   :agency_people, through: :agency_relations
 
-  validates_presence_of :year_of_birth, :job_seeker_status_id #,:resume
+  validates_presence_of :year_of_birth, :job_seeker_status_id
   validates  :year_of_birth, :year_of_birth => true
 
   def is_job_seeker?

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -5,9 +5,24 @@ class Resume < ActiveRecord::Base
 
   validates_presence_of :file, on: :create
   validates_presence_of :file_name, :job_seeker_id
+  validate :acceptable_file_type
 
-  # Valid file types for résumé files:
-  FILETYPES = ['pdf', 'doc', 'docx']
+  def acceptable_file_type
+    return if not file_name
+    mime_type = MIME::Types.type_for(URI.escape(file_name))
+    # Below is using 'if not' since 'unless' construct does not
+    # seem to short-circuit the rest of the statement with the
+    # result that 'content_type' could be called on nil
+    return if not mime_type.empty? and
+          MIMETYPES.include? mime_type.first.content_type
+
+    errors[:file_name] << 'unsupported file type'
+  end
+
+  # Valid MIME types for résumé files: pdf, doc, docx, pages
+  MIMETYPES = ['application/pdf', 'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/x-iwork-pages-sffpages']
 
   def initialize(file: nil, file_name: nil, job_seeker_id: nil)
     super

--- a/app/services/cruncher_service.rb
+++ b/app/services/cruncher_service.rb
@@ -4,12 +4,10 @@ class CruncherService
 
   @@auth_token = nil
 
-  def self.service_url=(url) # called from initializer
-    @@service_url = url
-  end
-
   def self.service_url
-    @@service_url
+    # Changed to use constant instead of class var as Rails reloads all
+    # classes on each request (unless config.cache_classes = true)
+    CRUNCHER_URL
   end
 
   def self.upload_file(file, file_name, file_id)
@@ -17,7 +15,7 @@ class CruncherService
 
     raise "Invalid MIME type for file: #{file_name}" if mime_type.empty?
     raise "Unsupported file type for: #{file_name}" if
-          not Resume::FILETYPES.include? mime_type.first.preferred_extension
+          not Resume::MIMETYPES.include? mime_type.first.content_type
 
     retry_upload = true
     begin

--- a/app/views/job_seekers/_form.html.haml
+++ b/app/views/job_seekers/_form.html.haml
@@ -13,7 +13,7 @@
 	.form-group
 		=js.label :resume, 'Resume', class:'control-label col-sm-2'
 		.col-sm-6
-			=js.file_field :resume
+			=js.file_field :resume, accept: Resume::MIMETYPES.join(',')
 	.form-group
 		.col-sm-2.col-sm-offset-2
 			=js.submit class: 'btn btn-primary'

--- a/config/initializers/cruncher_service.rb
+++ b/config/initializers/cruncher_service.rb
@@ -1,5 +1,7 @@
-CruncherService.service_url = ENV['CRUNCHER_SERVICE_URL'] ||
-                              'http://localhost:8443/api/v1'
+# Using a constant instead of a CruncherService class var since
+# Rails reloads all classes for each request in development mode
+CRUNCHER_URL = ENV['CRUNCHER_SERVICE_URL'] ||
+                   'http://localhost:8443/api/v1'
 
 # To enable the RestClient logger, export this env var at the
 # command line (before starting rails server), e.g.:

--- a/features/job_seeker.feature
+++ b/features/job_seeker.feature
@@ -30,6 +30,20 @@ Scenario: new Js Registration
   Then I click the "Create Job seeker" button
   Then I should see "A message with a confirmation and link has been sent to your email address. Please follow the link to activate your account."
 
+Scenario: Invalid résumé file type
+  Given I am on the Jobseeker Registration page
+  When I fill in "First Name" with "test"
+  And I fill in "Last Name" with "js80"
+  And I fill in "Email" with "testjobseeker80@gmail.com"
+  And I fill in "Phone" with "345-890-7890"
+  And I fill in "Password" with "password"
+  And I fill in "Password Confirmation" with "password"
+  And I fill in "Year Of Birth" with "1990"
+  Then I select "Unemployedlooking" in select list "Status"
+  And I choose resume file "Test File.zzz"
+  Then I click the "Create Job seeker" button
+  Then I should see "File name unsupported file type"
+
 Scenario: login action as jobseeker
   Given I am on the home page
   And I login as "vijaya.karumudi@gmail.com" with password "password"

--- a/features/job_seeker.feature
+++ b/features/job_seeker.feature
@@ -9,7 +9,7 @@ Background: seed data added to database
   Given the following jobseekerstatus values exist:
   | value                | description |
   | Unemployedlooking    | A jobseeker without any work and looking for a job|
-  | Employedlooking      | A jobseeker with a job and looking for a job      | 
+  | Employedlooking      | A jobseeker with a job and looking for a job      |
   | Employednotlooking   | A jobseeker with a job and not looking for a job for now.|
 
   Given the following jobseeker exist:
@@ -26,8 +26,9 @@ Scenario: new Js Registration
   And I fill in "Password Confirmation" with "password"
   And I fill in "Year Of Birth" with "1990"
   Then I select "Unemployedlooking" in select list "Status"
+  And I choose resume file "Admin-Assistant-Resume.pdf"
   Then I click the "Create Job seeker" button
-  Then I should see "A message with a confirmation and link has been sent  to your email address. Please follow the link to activate your account."
+  Then I should see "A message with a confirmation and link has been sent to your email address. Please follow the link to activate your account."
 
 Scenario: login action as jobseeker
   Given I am on the home page
@@ -52,13 +53,13 @@ Scenario: edit Js Registration without password change
   And I login as "vijaya.karumudi@gmail.com" with password "password"
   Then I should see "Signed in successfully"
   When I click the "vijaya" link
-  And I fill in "First Name" with "vijaya1" 
+  And I fill in "First Name" with "vijaya1"
   Then I select "Employednotlooking" in select list "Status"
-  Then I click the "Update Job seeker" button 
+  Then I click the "Update Job seeker" button
   Then I should see "Jobseeker was updated successfully."
 
-@javascript 
-Scenario: delete jobseeker 
+@javascript
+Scenario: delete jobseeker
   Given I am on the JobSeeker Show page for "vijaya.karumudi@gmail.com"
   Then I click and accept the "Delete Jobseeker" button
   And I wait for 1 seconds
@@ -68,4 +69,3 @@ Scenario:cancel redirect to homepage
   Given I am on the JobSeeker Show page for "vijaya.karumudi@gmail.com"
   Then I click the "Cancel" link
   Then I should be on the home page
-

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -136,3 +136,7 @@ Then(/^I select2 "([^"]*)" from "([^"]*)"$/) do |value, select_name|
     find("li", text: value).click
   end
 end
+
+When /^I choose resume file "([^"]*)"$/ do |filename|
+  attach_file('Resume', "#{Rails.root}/spec/fixtures/files/#{filename}")
+end

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -14,12 +14,11 @@ RSpec.describe JobSeekersController, type: :controller do
 
   describe "POST #create" do
     context "valid attributes" do
-     before(:each) do
+      before(:each) do
        ActionMailer::Base.deliveries.clear
-       @jobseeker = FactoryGirl.create(:job_seeker)
-       @user = FactoryGirl.create(:user)
-       @jobseekerstatus = FactoryGirl.create(:job_seeker_status)
-       @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker).merge(FactoryGirl.attributes_for(:user)).merge(FactoryGirl.attributes_for(:job_seeker_status))
+       @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker).
+              merge(FactoryGirl.attributes_for(:user)).
+              merge(FactoryGirl.attributes_for(:job_seeker_status))
        post :create, job_seeker: @jobseeker_hash
      end
 
@@ -30,7 +29,7 @@ RSpec.describe JobSeekersController, type: :controller do
      it 'returns redirect status' do
         expect(response).to have_http_status(:redirect)
      end
-     it 'redirects to mainpage' do
+     it 'redirects to root page' do
        expect(response).to redirect_to(root_path)
      end
      describe "confirmation email" do
@@ -52,16 +51,51 @@ RSpec.describe JobSeekersController, type: :controller do
        it { is_expected.to have_subject(/Confirmation instructions/) }
      end
     end
+
+    context "valid attributes and resume file upload" do
+     before(:each) do
+       stub_request(:post, CruncherService.service_url + '/authenticate').
+          to_return(body: "{\"token\": \"12345\"}", status: 200,
+          :headers => {'Content-Type'=> 'application/json'})
+
+       stub_request(:post, CruncherService.service_url + '/curriculum/upload').
+          to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,
+          :headers => {'Content-Type'=> 'application/json'})
+
+       ActionMailer::Base.deliveries.clear
+       @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker,
+              resume: fixture_file_upload('files/Janitor-Resume.doc')).
+              merge(FactoryGirl.attributes_for(:user)).
+              merge(FactoryGirl.attributes_for(:job_seeker_status))
+     end
+
+     it 'saves job seeker' do
+       expect{ post :create, job_seeker: @jobseeker_hash }.
+          to change(JobSeeker, :count).by(+1)
+     end
+     it 'saves resume record' do
+       expect{ post :create, job_seeker: @jobseeker_hash }.
+          to change(Resume, :count).by(+1)
+     end
+    end
+
     context 'invalid attributes' do
      before(:each) do
        @jobseeker = FactoryGirl.create(:job_seeker)
        @user = FactoryGirl.create(:user)
        @jobseekerstatus = FactoryGirl.create(:job_seeker_status)
        @jobseeker.assign_attributes(year_of_birth: '198')
-       @user.assign_attributes(first_name:'John',last_name:'Smith',phone:'890-789-9087')
-       @jobseekerstatus.assign_attributes(description:'MyText')
+       @user.assign_attributes(first_name: 'John', last_name: 'Smith',
+                               phone: '890-789-9087')
+       @jobseekerstatus.assign_attributes(description: 'MyText')
        @jobseeker.valid?
-       jobseeker1_hash = FactoryGirl.attributes_for(:job_seeker, year_of_birth: '198').merge(FactoryGirl.attributes_for(:user,first_name:'John',last_name:'Smith', phone:'890-789-9087')).merge(FactoryGirl.attributes_for(:job_seeker_status, value=nil, description:'MyText'))
+       jobseeker1_hash = FactoryGirl.attributes_for(:job_seeker,
+            year_of_birth: '198',
+            resume: fixture_file_upload('files/Janitor-Resume.doc')).
+            merge(FactoryGirl.attributes_for(:user, first_name: 'John',
+                   last_name: 'Smith', phone: '890-789-9087')).
+            merge(FactoryGirl.attributes_for(:job_seeker_status,
+                   value=nil, description:'MyText'))
        post :create, job_seeker: jobseeker1_hash
 
      end
@@ -81,10 +115,10 @@ RSpec.describe JobSeekersController, type: :controller do
    context "valid attributes" do
      before(:each) do
        @jobseeker =  FactoryGirl.create(:job_seeker)
-       @jobseekerstatus =  FactoryGirl.create(:job_seeker_status)
-       patch :update, id: @jobseeker,job_seeker: FactoryGirl.attributes_for(:job_seeker).
-merge(FactoryGirl.attributes_for(:job_seeker_status))
-
+       patch :update, id: @jobseeker,
+            job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                resume: fixture_file_upload('files/Janitor-Resume.doc')).
+            merge(FactoryGirl.attributes_for(:job_seeker_status))
      end
 
      it 'sets flash message' do

--- a/spec/factories/job_seekers.rb
+++ b/spec/factories/job_seekers.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :job_seeker do
     year_of_birth "1998"
-    resume "MyString"
+    resume nil
     job_seeker_status_id "Employedlooking"
     user
   end

--- a/spec/models/resume_spec.rb
+++ b/spec/models/resume_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Resume, type: :model do
       resume = Resume.new(file: file,
                           file_name: 'Test File.zzz',
                           job_seeker_id: job_seeker.id)
-      expect{ resume.save }.to raise_error(RuntimeError)
+      expect(resume.save).to be false
       expect(Resume.count).to eq 0
     end
 
@@ -111,7 +111,7 @@ RSpec.describe Resume, type: :model do
       resume = Resume.new(file: file,
                           file_name: 'nil',
                           job_seeker_id: job_seeker.id)
-      expect{ resume.save }.to raise_error(RuntimeError)
+      expect(resume.save).to be false
       expect(Resume.count).to eq 0
     end
   end


### PR DESCRIPTION
Simple, initial implementation of résumé upload upon job seeker registration.

This PR does not:

1. Cache résumé file for later upload if cruncher service is unavailable
2. Address résumé change upon job seeker profile edit
3. Accommodate more than one résumé per job seeker.