### PR TITLE
Closes AgileVentures/MetPlus_tracker#257

### DIFF
--- a/app/controllers/agency_people_controller.rb
+++ b/app/controllers/agency_people_controller.rb
@@ -13,11 +13,11 @@ class AgencyPeopleController < ApplicationController
   def home
     @agency_person = AgencyPerson.find(params[:id])
     @agency = @agency_person.agency
+    @task_type = 'mine-open'
     @js_without_jd = JobSeeker.paginate(:page=> params[:js_without_jd_page], :per_page=>5).js_without_jd
     @js_without_cm = JobSeeker.paginate(:page=> params[:js_without_cm_page], :per_page=>5).js_without_cm
     @your_jobseekers_jd = JobSeeker.paginate(:page=> params[:your_jobseekers_jd_page], :per_page=> 5).your_jobseekers_jd(@agency_person)
     @your_jobseekers_cm = JobSeeker.paginate(:page=> params[:your_jobseekers_cm_page], :per_page=> 5).your_jobseekers_cm(@agency_person)
-
   end
 
   def update

--- a/app/views/agency_people/home.html.haml
+++ b/app/views/agency_people/home.html.haml
@@ -5,8 +5,8 @@
     :id => 'edit-profile' do
     %i.fa.fa-pencil-square-o.fa-1
 
-%h3 Tasks that need your attention
-%i Tasks would go here
+%h3 Your Open Tasks
+= render partial: 'tasks/tasks_structure' , :locals => {task_type: @task_type}
 
 - if @agency_person.is_case_manager?(@agency)
   %h3 Your Job Seekers (Case Manager)
@@ -39,35 +39,36 @@
     = will_paginate @your_jobseekers_cm, param_name: 'your_jobseekers_cm_page'
     .clearfix
 
-    %h3 Job Seekers Without a Case Manager
-    - if @js_without_cm.empty?
-      %i All job seekers have a Case Manager at the moment.
-    -else
-      .col-sm-9
-        %table.table.table-hover
-          %thead
+
+  %h3 Job Seekers Without a Case Manager
+  - if @js_without_cm.empty?
+    %i All job seekers have a Case Manager at the moment.
+  -else
+    .col-sm-9
+      %table.table.table-hover
+        %thead
+          %tr
+            %td
+              %strong Name
+            %td
+              %strong Status
+            %td
+              %strong Last Login
+        %tbody
+          - @js_without_cm.each do |js|
             %tr
               %td
-                %strong Name
+                = js.full_name
               %td
-                %strong Status
+                - unless js.job_seeker_status.nil?
+                  = js.job_seeker_status.short_description
               %td
-                %strong Last Login
-          %tbody
-            - @js_without_cm.each do |js|
-              %tr
-                %td
-                  = js.full_name
-                %td
-                  - unless js.job_seeker_status.nil?
-                    = js.job_seeker_status.short_description
-                %td
-                  - if js.last_sign_in_at.nil?
-                    %i never
-                  - else
-                    = js.last_sign_in_at
-        = will_paginate @js_without_jd, param_name: 'js_without_cm_page'
-      .clearfix
+                - if js.last_sign_in_at.nil?
+                  %i never
+                - else
+                  = js.last_sign_in_at
+      = will_paginate @js_without_jd, param_name: 'js_without_cm_page'
+    .clearfix
 
 - if @agency_person.is_job_developer?(@agency)
   %h3 Your Job Seekers
@@ -91,7 +92,7 @@
                 = js.full_name
               %td
                 - unless js.job_seeker_status.nil?
-                  = js.status.short_description
+                  = js.job_seeker_status.short_description
               %td
                 - if js.last_sign_in_at.nil?
                   %i never

--- a/features/agency_person.feature
+++ b/features/agency_person.feature
@@ -1,40 +1,37 @@
 Feature: Agency Person
 
-  As a user
-  I want to login
-  So that I can edit my information
+  As an user
+  I want to login to PETS
+  And manage my work from my home page
 
-  Background:
-    Given the following agency roles exist:
-      | role  |
-      | AA    |
-      | CM    |
-      | JD    |
+  Background: seed data added to database and log in as agency admim
 
-    Given the following agencies exist:
-      | name    | website     | phone        | email                  | fax          |
-      | MetPlus | metplus.org | 555-111-2222 | pets_admin@metplus.org | 617-555-1212 |
+    Given the default settings are present
 
     Given the following agency people exist:
-      | agency  | role  | first_name | last_name | email            | password  |  phone       |
-      | MetPlus | AA    | John       | Smith     | aa@metplus.org   | qwerty123 | 555-222-3334 |
-      | MetPlus | CM    | Jane       | Jones     | jane@metplus.org | qwerty123 | 555-222-3334 |
+      | agency  | role      | first_name | last_name | phone        | email                | password  |
+      | MetPlus | AA,CM,JD  | John       | Smith     | 555-111-2222 | aa@metplus.org       | qwerty123 |
+      | MetPlus | CM        | Jane       | Jones     | 555-111-2222 | jane@metplus.org     | qwerty123 |
+      | MetPlus | JD        | Jane       | Developer | 555-111-2222 | jane-dev@metplus.org | qwerty123 |
+      | MetPlus | JD        | Bill       | Developer | 555-111-2222 | bill@metplus.org     | qwerty123 |
 
-    Given the following company roles exist:
-      | role  |
-      | CA    |
-      | CC    |
+    Given the following jobseeker exist:
+      | first_name| last_name| email                     | phone       |password  |password_confirmation| year_of_birth |job_seeker_status |
+      | John      | Seeker   | john-seeker@gmail.com     | 345-890-7890| password |password             | 1990          |Unemployed Seeking |
+      | John      | Worker   | john-worker@gmail.com     | 345-890-7890| password |password             | 1990          |Employed Looking   |
 
-    Given the following companies exist:
-      | agency  | name         | website     | phone        | email            | ein        | status |
-      | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
 
-    Given the following company people exist:
-      | company      | role  | first_name | last_name | email            | password  | phone        |
-      | Widgets Inc. | CA    | John       | Smith     | ca@widgets.com   | qwerty123 | 555-222-3334 |
-      | Widgets Inc. | CC    | Jane       | Smith     | jane@widgets.com | qwerty123 | 555-222-3334 |
+    Given the following tasks exist:
+      | task_type          | owner                | deferred_date | status      | targets               |
+      | need_job_developer | MetPlus,JD           | 2016-03-10    | NEW         | john-seeker@gmail.com |
+      | need_case_manager  | MetPlus,CM           | 2016-03-10    | NEW         | john-seeker@gmail.com |
+      | need_job_developer | jane-dev@metplus.org | 2016-03-10    | ASSIGNED    | john-worker@gmail.com |
+      | need_case_manager  | jane@metplus.org     | 2016-03-10    | WIP         | john-worker@gmail.com |
+      | need_case_manager  | aa@metplus.org       | 2016-03-10    | ASSIGNED    | john-seeker@gmail.com |
+      | need_job_developer | aa@metplus.org       | 2016-03-10    | WIP         | john-seeker@gmail.com |
+      | need_job_developer | aa@metplus.org       | 2016-03-10    | DONE        | john-worker@gmail.com |
 
-  Scenario: Agency Person login and edit from home page
+  Scenario: Case Manager login and edit from home page
     Given I am on the home page
     And I login as "jane@metplus.org" with password "qwerty123"
     And I should be on the Agency Person 'jane@metplus.org' Home page
@@ -47,3 +44,60 @@ Feature: Agency Person
     And I should see "Your profile was updated successfully."
     And I should not see "Jane"
     And I should see "Samantha"
+
+  Scenario: Job Developer login without tasks from home page
+    Given I am on the home page
+    And I login as "bill@metplus.org" with password "qwerty123"
+    And I should be on the Agency Person 'bill@metplus.org' Home page
+    And I should see "Your Open Tasks"
+    And I should not see "Job Seeker has no assigned Job Developer"
+    And I should see "Your Job Seekers"
+    And I should see "There are no job seekers assigned to you yet."
+    And I should not see "Job Seekers Without a Case Manager"
+
+  @selenium
+  Scenario: Case Manager with tasks on home page
+    Given I am on the home page
+    And I login as "jane@metplus.org" with password "qwerty123"
+    And I should be on the Agency Person 'jane@metplus.org' Home page
+    And I wait 2 seconds
+    And I should see "Your Open Tasks"
+    And I should see "Job Seeker has no assigned Case Manager"
+    And I should see "Work in progress( Jones, Jane )"
+    And I should not see "You have no open tasks at this time"
+    Then I press the done button of the task 4
+    And I wait 1 second
+    And I should see notification "Work on the task is done"
+
+  @selenium
+  Scenario: Job Developer with tasks on home page
+    Given I am on the home page
+    And I login as "jane-dev@metplus.org" with password "qwerty123"
+    And I should be on the Agency Person 'jane-dev@metplus.org' Home page
+    And I should see "Your Open Tasks"
+    And I should see "Job Seeker has no assigned Job Developer"
+    And I should not see "Job Seeker has no assigned Case Manager"
+    And The task 3 status is "Assigned"
+    Then I press the wip button of the task 3
+    And I wait 5 seconds
+    And I should see notification "Work on the task started"
+    And The task 3 status is "Work in progress"
+    Then I press the done button of the task 3
+    And I wait 1 second
+    And I should see notification "Work on the task is done"
+
+
+  @selenium
+  Scenario: Agency admin assign task to other JD and task is removed from his view
+    Given I am on the home page
+    And I login as "aa@metplus.org" with password "qwerty123"
+    And I should be on the Agency Person 'aa@metplus.org' Home page
+    And I wait 2 seconds
+    And The tasks 1,2,5,6 are present
+    Then I press the assign button of the task 2
+    And I should see "Select the user to assign the task to:"
+    And I select2 "Jones, Jane" from "task_assign_select"
+    Then I press "Assign"
+    And I wait 1 second
+    And I should see notification "Task assigned"
+    And The task 2 is not present

--- a/features/company_registration.feature
+++ b/features/company_registration.feature
@@ -81,18 +81,19 @@ Scenario: company registration approval
   When "hughjobs@widgets.com" opens the email with subject "Confirmation instructions"
   Then they should see "You can confirm your account email through the link below:" in the email body
 
-@javascript
+@selenium
 Scenario: company registration delete
   And I click the "Create" button
   Given I am logged in as agency admin
   And I click the "Admin" link
   And I click the "Agency and Partner Companies" link
   Then I click the "Widgets, Inc." link
+  Then I wait 2 seconds
   And I should see "Pending Registration"
   Then I click and accept the "Delete Registration" button
   Then I should see "Registration for 'Widgets, Inc.' deleted."
 
-@javascript
+@selenium
 Scenario: attempt login after registration is deleted
   And I click the "Create" button
   Given I am logged in as agency admin
@@ -106,7 +107,7 @@ Scenario: attempt login after registration is deleted
   And I login as "hughjobs@widgets.com" with password "qwerty123"
   Then I should see "Invalid email or password."
 
-@javascript
+@selenium
 Scenario: company registration denial
   And I click the "Create" button
   Given I am logged in as agency admin
@@ -122,7 +123,7 @@ Scenario: company registration denial
   Then I should see "Registration Denied"
   Then "hughjobs@widgets.com" should receive an email with subject "Registration denied"
 
-@javascript
+@selenium
 Scenario: attempt login after registration is denied
   And I click the "Create" button
   Given I am logged in as agency admin

--- a/features/jobs.feature
+++ b/features/jobs.feature
@@ -19,7 +19,7 @@ Scenario: Creating, Updating, and Deleting Job successfully and unsuccessfully
 	And I fill in the fields:
 		| Title                  | cashier|
 		| Job id                 | KARK12 |
-		| Description            | Atleast two years work experience|
+		| Description            | At least two years work experience|
 	And  I select "Day" in select list "Shift"
 	And  I check "Fulltime"
 	And  I press "new-job-submit"

--- a/features/step_definitions/devise_steps.rb
+++ b/features/step_definitions/devise_steps.rb
@@ -16,16 +16,15 @@ end
 
 
 Given(/^I am logged in as company person$/) do
-	FactoryGirl.create(:company_person)
+	person = FactoryGirl.create(:company_person)
 	step %{I am on the home page}
-  step %{I login as "unique1@gmail.com" with password "qwerty123"}
-   step %{I should be on the Company Person 'unique1@gmail.com' Home page}
+  step %{I login as "#{person.email}" with password "qwerty123"}
+  step %{I should be on the Company Person '#{person.email}' Home page}
 end
 
 Given(/^I am logged in as job developer$/) do
   agency = FactoryGirl.create(:agency)
-  FactoryGirl.create(:job_developer, :agency => agency)
+  person = FactoryGirl.create(:job_developer, :agency => agency)
   step %{I am on the home page}
-  step %{I login as "unique2@gmail.com" with password "qwerty123"}
+  step %{I login as "#{person.email}" with password "qwerty123"}
 end
-


### PR DESCRIPTION
Addition of 'my open tasks' partial to AP homepage w/ cucumber integration tests:
Tasks for 
JD
CM
can move tasks forward
can only see role-specific tasks
will see ‘you have no tasks’ if no tasks

AA
that AA can see all OPEN tasks
can assign tasks
that tasks disappear from AA view when assigned to another AP

Tests improvement:
devise_steps.rb - from hard-coded to object property
jobs.feature - from poltergeist to selenium 
company_registration.feature - corrected misspelling