### PR TITLE
Closes AgileVentures/MetPlus_tracker#326

### DIFF
--- a/app/assets/javascripts/agency_admin.js
+++ b/app/assets/javascripts/agency_admin.js
@@ -281,27 +281,27 @@ var AgencyData = {
   },
 
   setup_branches: function () {
-    $('#toggle_branches').click(AgencyData.toggle);
+    $('#toggle_branches').click(ManageData.toggle);
     $('#branches_table').on('click', '.pagination a',
                             ManageData.update_paginate_data);
   },
   setup_people: function () {
-    $('#toggle_people').click(AgencyData.toggle);
+    $('#toggle_people').click(ManageData.toggle);
     $('#people_table').on('click', '.pagination a',
                             ManageData.update_paginate_data);
   },
   setup_companies: function () {
-    $('#toggle_companies').click(AgencyData.toggle);
+    $('#toggle_companies').click(ManageData.toggle);
     $('#companies_table').on('click', '.pagination a',
                             ManageData.update_paginate_data);
   },
   setup_job_categories: function () {
-    $('#toggle_job_categories').click(AgencyData.toggle);
+    $('#toggle_job_categories').click(ManageData.toggle);
     $('#job_categories_table').on('click', '.pagination a',
                             ManageData.update_paginate_data);
   },
   setup_skills: function () {
-    $('#toggle_skills').click(AgencyData.toggle);
+    $('#toggle_skills').click(ManageData.toggle);
     $('#skills_table').on('click', '.pagination a',
                             ManageData.update_paginate_data);
   },

--- a/app/assets/javascripts/data_management.js
+++ b/app/assets/javascripts/data_management.js
@@ -1,5 +1,22 @@
 var ManageData = {
 
+  toggle: function () {
+    // Toggles (hide or show) via an anchor element ($this) bound to
+    // 'click' event.  The 'href' attribute of the element is the
+    // id of the content (table, div, etc.) to be toggled
+    var toggle_id = $(this).attr('href');
+
+    if (/Show/.test($(this).text())) {
+      $(toggle_id).show(800);
+      $(this).text($(this).text().replace('Show', 'Hide'));
+    } else {
+      $(toggle_id).hide(800);
+      $(this).text($(this).text().replace('Hide', 'Show'));
+    };
+
+    return(false);
+  },
+
   change_data_error: function (exception, xhrObj, model_errors_id) {
     // This helper function is called when an object 'new' or 'update'
     // action (invoked via ajax) returns with an error.

--- a/app/assets/javascripts/job_seekers.coffee
+++ b/app/assets/javascripts/job_seekers.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/job_seekers.js
+++ b/app/assets/javascripts/job_seekers.js
@@ -1,0 +1,3 @@
+$(function () {
+  $('#toggle_info').click(ManageData.toggle);
+});

--- a/app/views/job_seekers/home.html.haml
+++ b/app/views/job_seekers/home.html.haml
@@ -1,34 +1,75 @@
-%h3 Your Information
-%div{:class => 'container'}
-  %div{class: 'div_align_left'}
-    %b First Name:
-    = @jobseeker.first_name
-    %br
-    %b Last Name:
-    = @jobseeker.last_name
-    %br
-    %b Status:
-    %br
-    = @jobseeker.status.short_description
-    %b Last Login:
-    - unless @jobseeker.last_sign_in_at.nil?
-      = @jobseeker.last_sign_in_at.strftime('%x')
+.row
+  .col-sm-3
+    %h3
+      Your Information
+      = link_to edit_job_seeker_path(@jobseeker),
+        :title => 'Edit information',
+        :id => 'edit-information' do
+        %i.fa.fa-pencil-square-o.fa-1
+    %a(id='toggle_info' href='#info_table' class='text-danger'
+                style='padding-left: 10px;')
+      Hide Your Information
 
-  %div{class: 'div_align_left'}
-    %b Case Manager:
-    - if @jobseeker.case_manager.nil?
-      %i None assigned
-    - else
-      = @jobseeker.case_manager.full_name
-    %br
-    %b Job Developer:
-    - if @jobseeker.job_developer.nil?
-      %i None assigned
-    - else
-      = @jobseeker.job_developer.full_name
-    %br
-  %div{class: 'div_align_left'}
-    = link_to 'Update your information', edit_job_seeker_path, class: 'btn btn-primary'
+  .col-sm-9
+    %table.table.table-hover#info_table
+      %tbody
+        %tr
+          %td
+            %strong Name
+          %td
+            = @jobseeker.full_name(last_name_first: false)
+        %tr
+          %td
+            %strong Email
+          %td
+            = @jobseeker.email
+        %tr
+          %td
+            %strong Phone
+          %td
+            = @jobseeker.phone
+        %tr
+          %td
+            %strong Address
+          %td
+            = single_line_address(@jobseeker.address)
+        %tr
+          %td
+            %strong Status
+          %td
+            = @jobseeker.status.short_description
+        %tr
+          %td
+            %strong Résumé
+          %td
+            - if @jobseeker.resumes.empty?
+              %i No résumé on file
+            - else
+              - resume = @jobseeker.resumes[0]
+              = resume.file_name
+              &nbsp; &nbsp (updated #{time_ago_in_words(resume.created_at)} ago)
+        %tr
+          %td
+            %strong Last Login
+          %td
+            - unless @jobseeker.last_sign_in_at.nil?
+              = @jobseeker.last_sign_in_at.strftime('%x')
+        %tr
+          %td
+            %strong Case Manager
+          %td
+            - if @jobseeker.case_manager.nil?
+              %i None assigned
+            - else
+              = @jobseeker.case_manager.full_name(last_name_first: false)
+        %tr
+          %td
+            %strong Job Developer
+          %td
+            - if @jobseeker.job_developer.nil?
+              %i None assigned
+            - else
+              = @jobseeker.job_developer.full_name(last_name_first: false)
 
 
 %h3 Your Applications

--- a/features/job_seeker.feature
+++ b/features/job_seeker.feature
@@ -52,9 +52,9 @@ Scenario: jobseeker homepage with no agency relations
   And I login as "vijaya.karumudi@gmail.com" with password "password"
   Then I should see "Signed in successfully."
   And I should be on the Job Seeker 'vijaya.karumudi@gmail.com' Home page
-  And I should see "First Name: vijaya"
-  And I should see "Case Manager: None assigned"
-  And I should see "Job Developer: None assigned"
+  And I should see "Name vijaya karumudi"
+  And I should see "Case Manager None assigned"
+  And I should see "Job Developer None assigned"
 
 Scenario: edit Js Registration
   Given I am on the home page


### PR DESCRIPTION
This includes changes associated with PR #285 - this PR should be rebased after that PR is merged.

This cleans up the first part of the JS home page view (see waffle issue).

It also refactors the javascript associated with toggling (show/hide) content, and uses that refactored code to toggle 'Your Information' on the JS home page.

The toggle feature was added because the JS home page will (in its current design) be very long since there are a lot of different data sets displayed on that view.   Being able to hide data sets will improve the user experience.