### PR TITLE
Closes AgileVentures/MetPlus_tracker#234 - convert jobseeker listings to partials on AP home page

### DIFF
--- a/app/views/agency_people/_job_seekers.html.haml
+++ b/app/views/agency_people/_job_seekers.html.haml
@@ -1,5 +1,4 @@
-#jobseekers_table
-%h3 This is a partial!
+
 %table.table.table-hover
   %thead
     %tr
@@ -10,7 +9,7 @@
       %td
         %strong Last Login
   %tbody
-    - job_seekers.each do |js|
+    - jobseekers.each do |js|
       %tr
         %td
           = js.full_name
@@ -22,4 +21,5 @@
             %i never
           - else
             = js.last_sign_in_at
-= will_paginate job_seekers, param_name: 'job_seekers_page'
+= will_paginate jobseekers
+.clearfix

--- a/app/views/agency_people/home.html.haml
+++ b/app/views/agency_people/home.html.haml
@@ -14,30 +14,7 @@
     %i There are no job seekers assigned to you yet.
   - else
     .col-sm-9
-    %table.table.table-hover
-      %thead
-        %tr
-          %td
-            %strong Name
-          %td
-            %strong Status
-          %td
-            %strong Last Login
-      %tbody
-        - @your_jobseekers_cm.each do |js|
-          %tr
-            %td
-              = js.full_name
-            %td
-              - unless js.job_seeker_status.nil?
-                = js.job_seeker_status.short_description
-            %td
-              - if js.last_sign_in_at.nil?
-                %i never
-              - else
-                = js.last_sign_in_at
-    = will_paginate @your_jobseekers_cm, param_name: 'your_jobseekers_cm_page'
-    .clearfix
+    = render partial: 'job_seekers' , :locals => {jobseekers: @your_jobseekers_cm}
 
 
   %h3 Job Seekers Without a Case Manager
@@ -45,30 +22,8 @@
     %i All job seekers have a Case Manager at the moment.
   -else
     .col-sm-9
-      %table.table.table-hover
-        %thead
-          %tr
-            %td
-              %strong Name
-            %td
-              %strong Status
-            %td
-              %strong Last Login
-        %tbody
-          - @js_without_cm.each do |js|
-            %tr
-              %td
-                = js.full_name
-              %td
-                - unless js.job_seeker_status.nil?
-                  = js.job_seeker_status.short_description
-              %td
-                - if js.last_sign_in_at.nil?
-                  %i never
-                - else
-                  = js.last_sign_in_at
-      = will_paginate @js_without_jd, param_name: 'js_without_cm_page'
-    .clearfix
+
+    = render partial: 'job_seekers' , :locals => {jobseekers: @js_without_cm}
 
 - if @agency_person.is_job_developer?(@agency)
   %h3 Your Job Seekers
@@ -76,56 +31,12 @@
     %i There are no job seekers assigned to you yet.
   - else
     .col-sm-9
-      %table.table.table-hover
-        %thead
-          %tr
-            %td
-              %strong Name
-            %td
-              %strong Status
-            %td
-              %strong Last Login
-        %tbody
-          - @your_jobseekers_jd.each do |js|
-            %tr
-              %td
-                = js.full_name
-              %td
-                - unless js.job_seeker_status.nil?
-                  = js.job_seeker_status.short_description
-              %td
-                - if js.last_sign_in_at.nil?
-                  %i never
-                - else
-                  = js.last_sign_in_at
-      = will_paginate @your_jobseekers_jd, param_name: 'your_jobseekers_jd_page'
-    .clearfix
+
+    = render partial: 'job_seekers' , :locals => {jobseekers: @your_jobseekers_jd}
 
   %h3 Job Seekers Without a Job Developer
   - if @js_without_jd.empty?
-    %i All job seekers have a Case Manager at the moment.
+    %i All job seekers have a Job Developer at the moment.
   - else
     .col-sm-9
-      %table.table.table-hover
-        %thead
-          %tr
-            %td
-              %strong Name
-            %td
-              %strong Status
-            %td
-              %strong Last Login
-        %tbody
-          - @js_without_jd.each do |js|
-            %tr
-              %td
-                = js.full_name
-              %td
-                - unless js.job_seeker_status.nil?
-                  = js.job_seeker_status.short_description
-              %td
-                - if js.last_sign_in_at.nil?
-                  %i never
-                - else
-                  = js.last_sign_in_at
-    = will_paginate @js_without_jd, param_name: 'js_without_jd_page'
+    = render partial: 'job_seekers' , :locals => {jobseekers: @js_without_jd}


### PR DESCRIPTION
Have replaced specified listings with a reusable partial. Bouncing off Semaphore for feature testing.