### PR TITLE
Closes AgileVentures/MetPlus_tracker#357

### DIFF
--- a/app/assets/javascripts/company_people.coffee
+++ b/app/assets/javascripts/company_people.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/company_people.js
+++ b/app/assets/javascripts/company_people.js
@@ -1,0 +1,3 @@
+$(function () {
+  $('#toggle_company_info').click(ManageData.toggle);
+});

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -13,7 +13,7 @@ class CompaniesController < ApplicationController
 
   def edit
     @company = Company.find(params[:id])
-
+    @admin_type = params[:admin_type]
   end
 
   def update
@@ -22,8 +22,14 @@ class CompaniesController < ApplicationController
     if @company.valid?
       @company.save
       flash[:notice] = "company was successfully updated."
-      redirect_to company_path(@company)
+      case params[:admin_type]
+      when 'CA'
+        redirect_to home_company_person_path(pets_user)
+      when 'AA'
+        redirect_to company_path(@company, admin_type: 'AA')
+      end
     else
+      @admin_type = params[:admin_type]
       render :edit
     end
   end

--- a/app/controllers/company_people_controller.rb
+++ b/app/controllers/company_people_controller.rb
@@ -66,6 +66,7 @@ class CompanyPeopleController < ApplicationController
     @job_type    = 'my-company-all'
     @people_type = 'my-company-all'
     @company     = pets_user.company
+    @company_admins = Company.company_admins(@company)
     @company_person = pets_user
   end
 

--- a/app/controllers/company_registrations_controller.rb
+++ b/app/controllers/company_registrations_controller.rb
@@ -104,7 +104,7 @@ class CompanyRegistrationsController < ApplicationController
     company_person.user.send_confirmation_instructions
 
     flash[:notice] = "Company contact has been notified of registration approval."
-    redirect_to company_path(company.id)
+    redirect_to company_path(company.id, admin_type: 'AA')
 
   end
 

--- a/app/controllers/concerns/company_people_viewer.rb
+++ b/app/controllers/concerns/company_people_viewer.rb
@@ -4,9 +4,9 @@ module CompanyPeopleViewer
   def display_company_people people_type, per_page = 10
     case people_type
     when 'my-company-all'
-      return CompanyPerson.paginate(page: params[:people_page],
-                                    per_page: per_page).
-                                    all_company_people(pets_user.company)
+      return CompanyPerson.joins(:user).order('users.last_name').
+              paginate(page: params[:people_page], per_page: per_page).
+              all_company_people(pets_user.company)
     end
   end
 

--- a/app/controllers/concerns/jobs_viewer.rb
+++ b/app/controllers/concerns/jobs_viewer.rb
@@ -4,7 +4,9 @@ module JobsViewer
   def display_jobs job_type, per_page = 10
     case job_type
       when 'my-company-all'
-        return Job.paginate(:page => params[:jobs_page], :per_page => per_page).find_by_company(pets_user.company)
+        return Job.order(:title).
+            paginate(:page => params[:jobs_page], :per_page => per_page).
+            find_by_company(pets_user.company)
     end
   end
 

--- a/app/views/agency_mailer/agency_notification.html.haml
+++ b/app/views/agency_mailer/agency_notification.html.haml
@@ -8,7 +8,7 @@
 
   - elsif @obj_type == 'Company'
     A company has requested registration in PETS:
-    = link_to @obj.name, company_url(id: @obj.id)
+    = link_to @obj.name, company_url(id: @obj.id, admin_type: 'AA')
 
   - elsif @obj_type == 'Job Application'
     A job seeker has applied to this job:

--- a/app/views/companies/_companies.html.haml
+++ b/app/views/companies/_companies.html.haml
@@ -15,7 +15,7 @@
             - if company.status == Company::STATUS[:PND]
               = link_to company.name, company_registration_path(company)
             - else
-              = link_to company.name, company_path(company)
+              = link_to company.name, company_path(company, admin_type: 'AA')
           %td
             = single_line_address(company.addresses.first)
           %td

--- a/app/views/companies/_company_info.html.haml
+++ b/app/views/companies/_company_info.html.haml
@@ -1,0 +1,49 @@
+%table.table.table-hover#company_info_table(style='margin-top: 5px;')
+  %tbody
+    %tr
+      %td
+        %strong Name
+      %td
+        = @company.name
+    %tr
+      %td
+        %strong EIN
+      %td
+        = @company.ein
+    %tr
+      %td
+        %strong Website
+      %td
+        = @company.website
+    %tr
+      %td
+        %strong Phone
+      %td
+        = @company.phone
+    %tr
+      %td
+        %strong Fax
+      %td
+        = @company.fax
+    %tr
+      %td
+        %strong Corporate Email
+      %td
+        = @company.email
+    %tr
+      %td
+        %strong Jobs Email
+      %td
+        = @company.job_email
+    %tr
+      %td
+        %strong Description
+      %td
+        = @company.description
+    %tr
+      %td
+        %strong Company Admin(s)
+      %td
+        - @company_admins.each do |ca|
+          = ca.full_name(last_name_first: false)
+          = ', ' if ca != @company_admins.last

--- a/app/views/companies/_company_status.html.haml
+++ b/app/views/companies/_company_status.html.haml
@@ -1,7 +1,6 @@
 = company.status
 - if company.status == Company::STATUS[:PND]
-  = link_to 'Approve',                                                 |
-      approve_company_registration_path(company), method: :patch,      |
-      class: 'btn btn-success btn-xs',                                 |
-      id: 'company_approve_link'                                       |
+  = link_to 'Approve',
+      approve_company_registration_path(company),
+      method: :patch, class: 'btn btn-success btn-xs', id: 'company_approve_link'
   - text_modal_button 'Deny', 'deny_registration'

--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -1,6 +1,6 @@
 
-= form_for company, url: company_path, method: :patch,                   |
-                              html: {class: 'form-horizontal'} do |f|    |
+= form_for company, url: url, method: method,
+                              html: {class: 'form-horizontal'} do |f|
   .col-sm-offset-2.col-sm-6
     = render 'shared/error_messages', object: company
     %br
@@ -10,6 +10,7 @@
 
   .form-group
     .col-sm-2.col-sm-offset-2
-      = submit_tag 'Submit', method: :patch, class: 'btn btn-primary'
+      -# = submit_tag 'Submit', method: :patch, class: 'btn btn-primary'
+      = f.submit submit, class: 'btn btn-primary'
     .col-sm-2.col-sm-offset-2
       = link_to 'Cancel', :back, class: 'btn btn-danger'

--- a/app/views/companies/company_admin/_company_info.html.haml
+++ b/app/views/companies/company_admin/_company_info.html.haml
@@ -45,5 +45,5 @@
         %strong Company Admin(s)
       %td
         - @company_admins.each do |ca|
-          = ca.full_name(last_name_first: false)
+          = mail_to ca.email, ca.full_name(last_name_first: false)
           = ', ' if ca != @company_admins.last

--- a/app/views/companies/edit.html.haml
+++ b/app/views/companies/edit.html.haml
@@ -1,4 +1,5 @@
 %h2 Edit Company
 
 = render partial: 'form', locals: {company: @company, method: :patch,
-                submit: 'Update', url: company_path(@company)}
+                  submit: 'Update',
+                  url: company_path(@company, admin_type: @admin_type)}

--- a/app/views/companies/edit.html.haml
+++ b/app/views/companies/edit.html.haml
@@ -1,5 +1,4 @@
 %h2 Edit Company
 
-= render partial: 'form', locals: {company: @company, method: :patch, |
-                submit: 'Update', url: company_path(@company),        |
-                cancel_url: company_path(@company)}                   |
+= render partial: 'form', locals: {company: @company, method: :patch,
+                submit: 'Update', url: company_path(@company)}

--- a/app/views/companies/edit.html.haml
+++ b/app/views/companies/edit.html.haml
@@ -1,5 +1,5 @@
 %h2 Edit Company
 
 = render partial: 'form', locals: {company: @company, method: :patch,
-                  submit: 'Update',
+                  submit: 'Submit',
                   url: company_path(@company, admin_type: @admin_type)}

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -4,17 +4,18 @@
 
 .row
   .col-sm-2
-    = button_to 'Edit Company', edit_company_path(@company), |
-                method: :get, class: 'btn btn-primary'       |
+    = button_to 'Edit Company',
+                edit_company_path(@company, admin_type: 'AA'),
+                method: :get, class: 'btn btn-primary'
 
   .col-sm-2.col-sm-offset-1
     - if @company.status == Company::STATUS[:ACT]
-      = link_to 'Invite Person',                                    |
-            new_user_invitation_path(person_type: 'CompanyPerson',  |
-                   org_id: @company.id),                            |
-            method: :get, class: 'btn btn-primary'                  |
+      = link_to 'Invite Person',
+            new_user_invitation_path(person_type: 'CompanyPerson',
+                   org_id: @company.id),
+            method: :get, class: 'btn btn-primary'
 
   .col-sm-2.col-sm-offset-1
-    = button_to 'Delete Company', company_path(@company), method: :delete,  |
-      data: {confirm: "Delete company #{@company.name}?"},                  |
-                      class: 'btn btn-danger'                               |
+    = button_to 'Delete Company', company_path(@company, admin_type: 'AA'),
+      method: :delete, data: {confirm: "Delete company #{@company.name}?"},
+                      class: 'btn btn-danger'

--- a/app/views/company_people/_list_people.html.haml
+++ b/app/views/company_people/_list_people.html.haml
@@ -20,7 +20,7 @@
         - case field
           - when :full_name
             %td.col-md-4
-              = person.full_name
+              = link_to person.full_name, company_person_path(person.id)
           - when :email
             %td.col-md-2
               = person.email

--- a/app/views/company_people/home.html.haml
+++ b/app/views/company_people/home.html.haml
@@ -9,7 +9,7 @@
   - if @company_person.is_company_admin? @company
     .col-sm-3.col-sm-offset-9{style: 'margin-top: 20px;'}
       = link_to 'Edit Company Info',
-                    edit_company_path(id: @company),
+                    edit_company_path(id: @company.id, admin_type: 'CA'),
                     method: :get, class: 'btn btn-primary btn-sm pull-right'
 
 .clearfix
@@ -19,7 +19,7 @@
               style='padding-left: 10px;')
     Hide Company Information
 .col-sm-9
-  = render partial: 'companies/company_info'
+  = render partial: 'companies/company_admin/company_info'
 
 .col-sm-12
   %h3 Tasks that need your attention

--- a/app/views/company_people/home.html.haml
+++ b/app/views/company_people/home.html.haml
@@ -12,6 +12,15 @@
                     edit_company_path(id: @company),
                     method: :get, class: 'btn btn-primary btn-sm pull-right'
 
+.clearfix
+.col-sm-3
+  %h4 Company Information
+  %a(id='toggle_company_info' href='#company_info_table' class='text-danger'
+              style='padding-left: 10px;')
+    Hide Company Information
+.col-sm-9
+  = render partial: 'companies/company_info'
+
 .col-sm-12
   %h3 Tasks that need your attention
   = render partial: 'tasks/tasks_structure' , :locals => {task_type: @task_type}

--- a/app/views/tasks/_tasks.html.haml
+++ b/app/views/tasks/_tasks.html.haml
@@ -1,66 +1,69 @@
-%table.table.table-hover
-  %thead
-    %tr
-      %td
-        Task
-      %td
-        Status
-      %td
-        Entities associated
-      %td
-        Change date
-      %td
-        Options
-  %tbody
-    - all_tasks.each do |task|
-      %tr{:id => "task-#{task.id}"}
+- if all_tasks.empty?
+  %i No outstanding tasks
+- else
+  %table.table.table-hover
+    %thead
+      %tr
         %td
-          = task.description
-        %td{:id => "task-#{task.id}-status"}
-          - if task.status == Task::STATUS[:NEW]
-            = task.status
-          - else
-            = "#{task.status}("
-            = link_to( task.task_owner.full_name, show_person_path(task.task_owner))
-            )
+          Task
         %td
-          - if not task.user.nil?
-            %p
-              User:
-              =link_to( task.person.full_name, show_person_path(task.person))
-          - if not task.job.nil?
-            %p
-              Job:
-              = link_to(task.job.title, job_path(task.job))
-          - if not task.company.nil?
-            %p
-              Company:
-              = link_to(task.company.name, company_home_path(task.company))
+          Status
         %td
-          = task.updated_at.strftime('%F')
+          Entities associated
         %td
-          - if task.status == Task::STATUS[:NEW] and policy(task).assign?
-            = link_to '#', :title => 'Assign task',
-                            class: 'assign_button',
-                            id: "assign-#{task.id}",
-                            data: { :task_id => task.id,
-                                    :toggle => 'modal',
-                                    :target => '#assignTaskModal'} do
-              %i.fa.fa-male.fa-1
-          - elsif task.status == Task::STATUS[:ASSIGNED] and policy(task).in_progress?
-            = link_to '#', :title => 'Start working on task',
-                           class: 'wip_button',
-                           id: "wip-#{task.id}",
-                           data: {:url => in_progress_task_path(task)} do
-              %i.fa.fa-hourglass-start.fa-1
-          - elsif task.status == Task::STATUS[:WIP] and policy(task).done?
-            = link_to '#', :title => 'Work complete',
-                           class: 'done_button',
-                           id: "done-#{task.id}",
-                           data: {:url => done_task_path(task)} do
-              %i.fa.fa-flag-checkered.fa-1
-.row.text-center
-  = will_paginate all_tasks, param_name: 'tasks_page', :params => {:controller => 'tasks', :action => 'tasks', :task_type => task_type}
+          Change date
+        %td
+          Options
+    %tbody
+      - all_tasks.each do |task|
+        %tr{:id => "task-#{task.id}"}
+          %td
+            = task.description
+          %td{:id => "task-#{task.id}-status"}
+            - if task.status == Task::STATUS[:NEW]
+              = task.status
+            - else
+              = "#{task.status}("
+              = link_to( task.task_owner.full_name, show_person_path(task.task_owner))
+              )
+          %td
+            - if not task.user.nil?
+              %p
+                User:
+                =link_to( task.person.full_name, show_person_path(task.person))
+            - if not task.job.nil?
+              %p
+                Job:
+                = link_to(task.job.title, job_path(task.job))
+            - if not task.company.nil?
+              %p
+                Company:
+                = link_to(task.company.name, company_home_path(task.company))
+          %td
+            = task.updated_at.strftime('%F')
+          %td
+            - if task.status == Task::STATUS[:NEW] and policy(task).assign?
+              = link_to '#', :title => 'Assign task',
+                              class: 'assign_button',
+                              id: "assign-#{task.id}",
+                              data: { :task_id => task.id,
+                                      :toggle => 'modal',
+                                      :target => '#assignTaskModal'} do
+                %i.fa.fa-male.fa-1
+            - elsif task.status == Task::STATUS[:ASSIGNED] and policy(task).in_progress?
+              = link_to '#', :title => 'Start working on task',
+                             class: 'wip_button',
+                             id: "wip-#{task.id}",
+                             data: {:url => in_progress_task_path(task)} do
+                %i.fa.fa-hourglass-start.fa-1
+            - elsif task.status == Task::STATUS[:WIP] and policy(task).done?
+              = link_to '#', :title => 'Work complete',
+                             class: 'done_button',
+                             id: "done-#{task.id}",
+                             data: {:url => done_task_path(task)} do
+                %i.fa.fa-flag-checkered.fa-1
+  .row.text-center
+    = will_paginate all_tasks, param_name: 'tasks_page', :params => {:controller => 'tasks', :action => 'tasks', :task_type => task_type}
 
 %script{:type=>"text/javascript"}
   $(document).ready( function() {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,11 +52,17 @@ Rails.application.routes.draw do
 
   # ----------------------- Company ------------------------------------------
   # Company admin (and agency admin) can edit a company
-  resources :companies, path: 'company_admin/companies',
-                                only: [:edit, :update, :show]
+  # resources :companies, path: 'company_admin/companies',
+  #                               only: [:edit, :update, :show]
   # Only the agency admin can delete a company
-  resources :companies, path: 'admin/companies',
-                                only: [:destroy, :list]
+  # resources :companies, path: 'admin/companies',
+  #                               only: [:destroy, :list]
+
+  get   'companies/:id/:admin_type'      => 'companies#show', as: :company
+  patch 'companies/:id/:admin_type'      => 'companies#update'
+  delete 'companies/:id'  => 'companies#destroy'
+  get   'companies/:id/edit/:admin_type' => 'companies#edit',
+                            as: :edit_company
 
   # --------------------------------------------------------------------------
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,17 +51,16 @@ Rails.application.routes.draw do
   # --------------------------------------------------------------------------
 
   # ----------------------- Company ------------------------------------------
-  # Company admin (and agency admin) can edit a company
-  # resources :companies, path: 'company_admin/companies',
-  #                               only: [:edit, :update, :show]
-  # Only the agency admin can delete a company
-  # resources :companies, path: 'admin/companies',
-  #                               only: [:destroy, :list]
+  # Most company actions can be performed by a company admin or an
+  # agency admin.  Redirect logic after actions can be different
+  # depending on which admin type is performing the action.
+  # (delete of a company can only be performed by an agency admin, but
+  # 'admin_type param is still used to conform to Rails path conventions')
 
-  get   'companies/:id/:admin_type'      => 'companies#show', as: :company
-  patch 'companies/:id/:admin_type'      => 'companies#update'
-  delete 'companies/:id'  => 'companies#destroy'
-  get   'companies/:id/edit/:admin_type' => 'companies#edit',
+  get    'companies/:id/:admin_type'  => 'companies#show', as: :company
+  patch  'companies/:id/:admin_type'  => 'companies#update'
+  delete 'companies/:id/:admin_type'  => 'companies#destroy'
+  get    'companies/:id/edit/:admin_type' => 'companies#edit',
                             as: :edit_company
 
   # --------------------------------------------------------------------------

--- a/features/company_person.feature
+++ b/features/company_person.feature
@@ -132,9 +132,9 @@ Feature: Company Person
     And I login as "ca@widgets.com" with password "qwerty123"
     And I should be on the Company Person 'ca@widgets.com' Home page
     And I wait for 5 seconds
-    And I should not see "Cook"
+    And I should see "Cook"
     And I should not see "Doctor"
-    And I should see "software developer"
+    And I should not see "software developer"
 
   @selenium
   Scenario: verify people listing in home page

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -67,6 +67,10 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Capybara.default_max_wait_time = 5
 
+Before '@selenium' do
+  Capybara.current_session.current_window.resize_to(1024, 768)
+end
+
 if ENV['IN_BROWSER']
   # On demand: non-headless tests via Selenium/WebDriver
   # To run the scenarios in browser (default: Firefox), use the following command line:

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CompaniesController, type: :controller do
   describe "GET #show" do
     let(:company)   { FactoryGirl.create(:company) }
     before(:each) do
-      get :show, id: company
+      get :show, id: company, admin_type: 'AA'
     end
     it 'assigns @company for view' do
       expect(assigns(:company)).to eq company
@@ -22,7 +22,7 @@ RSpec.describe CompaniesController, type: :controller do
     let(:company)  { FactoryGirl.create(:company) }
 
     before(:each) do
-      get :edit, id: company
+      get :edit, id: company, admin_type: 'AA'
     end
     it 'assigns @company for form' do
       expect(assigns(:company)).to eq company
@@ -45,7 +45,7 @@ RSpec.describe CompaniesController, type: :controller do
 
     context 'valid attributes' do
       it 'locates the requested company' do
-        patch :update, id: company, company: hash_params
+        patch :update, id: company, admin_type: 'AA', company: hash_params
         expect(assigns(:company)).to eq(company)
       end
 
@@ -56,7 +56,7 @@ RSpec.describe CompaniesController, type: :controller do
                           {'0' => attributes_for(:address),
                            '1' => attributes_for(:address) })
 
-        patch :update, id: company, company: params_hash
+        patch :update, admin_type: 'AA', id: company, company: params_hash
         company.reload
         expect(company.email).to eq('info@widgets.com')
         expect(company.fax).to eq('510 555-1212')
@@ -64,7 +64,7 @@ RSpec.describe CompaniesController, type: :controller do
       end
       it 'deletes company address' do
         hash_params[:addresses_attributes]['0']['_destroy'] = true
-        patch :update, id: company, company: hash_params
+        patch :update, admin_type: 'AA', id: company, company: hash_params
         company.reload
         expect(company.addresses.count).to eq 0
       end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -597,7 +597,8 @@ RSpec.describe JobsController, type: :controller do
       @ca1 = FactoryGirl.create(:company_admin, :company => company1)
       @job.destroy
       31.times.each do |i|
-        FactoryGirl.create(:job, :title => "Awesome job #{i}", :company => company, :company_person => @ca)
+        title = i < 10 ? "Awesome job 0#{i}" : "Awesome job #{i}"
+        FactoryGirl.create(:job, :title => title, :company => company, :company_person => @ca)
       end
       4.times.each do |i|
         FactoryGirl.create(:job, :title => "Awesome new job #{i}", :company => company1, :company_person => @ca1)
@@ -629,8 +630,8 @@ RSpec.describe JobsController, type: :controller do
         # paginate is also called
         assigns(:jobs).each do end
         expect(assigns(:jobs).all.size).to be 10
-        expect(assigns(:jobs).first.title).to eq 'Awesome job 0'
-        expect(assigns(:jobs).last.title).to eq 'Awesome job 9'
+        expect(assigns(:jobs).first.title).to eq 'Awesome job 00'
+        expect(assigns(:jobs).last.title).to eq 'Awesome job 09'
       end
 
       it { should_not set_flash }

--- a/spec/mailers/agency_mailer_spec.rb
+++ b/spec/mailers/agency_mailer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AgencyMailer, type: :mailer do
     end
     it "includes link to show company" do
       expect(mail).
-          to have_body_text(/#{company_url(id: 1)}/)
+          to have_body_text(/#{company_url(id: 1, admin_type: 'AA')}/)
     end
   end
 


### PR DESCRIPTION
This is based on code from PR #302 (waffle 346).  That PR should be merged first and then this rebased.

- Add company info display at top of page
  - [ ] Show company info ala agency info (in admin view)
  - [ ] 'Hide Info' / 'Show Info' link (like job seeker 'show' view)
  - [ ] Info shown includes 'Company Admin(s)'
  - [ ] Rendered by partial to be shared with agency person company-show view

- 'Edit Company Info' view
  - [ ] upon successful update, redirect back to CP home page

- 'Tasks that need your attention'
  - [ ] Hide if no outstanding tasks (or, shown 'No tasks outstanding')

- 'All <company> jobs'
  - [ ] Sort by job title

- Company people table
  - [ ] sort by last name
  - [ ] name is link to company person 'show' view

Note that I changed routes associated with companies, as the actions for company(s) can be performed by both company admin and agency admin people (company-delete can only be performed by agency admin).