### PR TITLE
Closes AgileVentures/MetPlus_tracker#359

### DIFF
--- a/app/policies/task_policy.rb
+++ b/app/policies/task_policy.rb
@@ -6,7 +6,11 @@ class TaskPolicy < ApplicationPolicy
     record.task_owner == user
   end
   def assign?
-    record.task_owner.include? user
+    if record.task_owner.is_a? Array
+      record.task_owner.include? user
+    else
+      record.task_owner == user
+    end
   end
   def tasks?
     not user.nil?

--- a/app/views/tasks/_tasks.html.haml
+++ b/app/views/tasks/_tasks.html.haml
@@ -38,7 +38,7 @@
             - if not task.company.nil?
               %p
                 Company:
-                = link_to(task.company.name, company_home_path(task.company))
+                = link_to(task.company.name, company_registration_path(task.company))
           %td
             = task.updated_at.strftime('%F')
           %td

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -157,6 +157,8 @@ Given(/^the following tasks exist:$/) do |table|
     end
     if targets =~ /@/
       task.target = User.find_by_email targets
+    else
+      task.target = Company.find_by_name targets
     end
     task.save!
   end

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -36,7 +36,7 @@ Feature: Have a task system in the site
       | need_case_manager  | aa@metplus.org       | 2016-03-10    | ASSIGNED    | john-seeker@gmail.com |
       | need_job_developer | aa@metplus.org       | 2016-03-10    | WIP         | john-seeker@gmail.com |
       | need_job_developer | aa@metplus.org       | 2016-03-10    | DONE        | john-worker@gmail.com |
-      | company_registration | aa@metplus.org     | 2016-03-10    | NEW         | Widgets Inc.          |
+      | company_registration | MetPlus,AA         | 2016-03-10    | NEW         | Widgets Inc.          |
 
 
   @selenium

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -33,7 +33,7 @@ Feature: Have a task system in the site
       | need_case_manager  | MetPlus,CM           | 2016-03-10    | NEW         | john-seeker@gmail.com |
       | need_job_developer | jane-dev@metplus.org | 2016-03-10    | ASSIGNED    | john-worker@gmail.com |
       | need_case_manager  | jane@metplus.org     | 2016-03-10    | WIP         | john-worker@gmail.com |
-      | need_case_manager  | aa@metplus.org       | 2016-03-10    | NEW    | john-seeker@gmail.com |
+      | need_case_manager  | aa@metplus.org       | 2016-03-10    | ASSIGNED    | john-seeker@gmail.com |
       | need_job_developer | aa@metplus.org       | 2016-03-10    | WIP         | john-seeker@gmail.com |
       | need_job_developer | aa@metplus.org       | 2016-03-10    | DONE        | john-worker@gmail.com |
       | company_registration | aa@metplus.org     | 2016-03-10    | NEW         | Widgets Inc.          |

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -19,15 +19,25 @@ Feature: Have a task system in the site
       | John      | Seeker   | john-seeker@gmail.com     | 345-890-7890| password |password             | 1990          |Unemployed Seeking |
       | John      | Worker   | john-worker@gmail.com     | 345-890-7890| password |password             | 1990          |Employed Looking   |
 
+    Given the following companies exist:
+      | agency  | name         | website     | phone        | email            | ein        | status |
+      | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Pending Registration |
+
+    Given the following company people exist:
+      | company      | role  | first_name | last_name | email            | password  | phone        |
+      | Widgets Inc. | CA    | Steve      | Jobs      | ca@widgets.com   | qwerty123 | 555-222-3334 |
+
     Given the following tasks exist:
       | task_type          | owner                | deferred_date | status      | targets               |
       | need_job_developer | MetPlus,JD           | 2016-03-10    | NEW         | john-seeker@gmail.com |
       | need_case_manager  | MetPlus,CM           | 2016-03-10    | NEW         | john-seeker@gmail.com |
       | need_job_developer | jane-dev@metplus.org | 2016-03-10    | ASSIGNED    | john-worker@gmail.com |
       | need_case_manager  | jane@metplus.org     | 2016-03-10    | WIP         | john-worker@gmail.com |
-      | need_case_manager  | aa@metplus.org       | 2016-03-10    | ASSIGNED    | john-seeker@gmail.com |
+      | need_case_manager  | aa@metplus.org       | 2016-03-10    | NEW    | john-seeker@gmail.com |
       | need_job_developer | aa@metplus.org       | 2016-03-10    | WIP         | john-seeker@gmail.com |
       | need_job_developer | aa@metplus.org       | 2016-03-10    | DONE        | john-worker@gmail.com |
+      | company_registration | aa@metplus.org     | 2016-03-10    | NEW         | Widgets Inc.          |
+
 
   @selenium
   Scenario: Job Developer assigns tasks and complete it
@@ -61,7 +71,7 @@ Feature: Have a task system in the site
     And I login as "aa@metplus.org" with password "qwerty123"
     Then I should see "Signed in successfully."
     Then I go to the tasks page
-    And The tasks 1,2,5,6,7 are present
+    And The tasks 1,2,5,6,7,8 are present
     And I should see "Job Seeker has no assigned Job Developer"
     And I should see "Job Seeker has no assigned Job Developer" after "Tasks completed by you"
     Then I press the assign button of the task 2
@@ -71,6 +81,18 @@ Feature: Have a task system in the site
     And I wait 1 second
     And I should see notification "Task assigned"
     And The task 2 is not present
+
+  @selenium
+  Scenario: Agency admin can see company registration
+    Given I am on the home page
+    And I login as "aa@metplus.org" with password "qwerty123"
+    Then I should see "Signed in successfully."
+    Then I go to the tasks page
+    And I wait 2 seconds
+    And I should see "Widgets Inc."
+    And I click the "Widgets Inc." link
+    And I wait 1 second
+    And I should see "Company Registration Information"
 
   @selenium
   Scenario: Case Manager open and closes assign modal


### PR DESCRIPTION
- [ ] For 'company_registration' task, changed object linked to in task table from company home page to company registration page.

- [ ] I changed this policy method in task_policy.rb from:
```
def assign?
   record.task_owner.include? user
end
```
to
```
def assign?
    if record.task_owner.is_a? Array
      record.task_owner.include? user
    else
      record.task_owner == user
    end
end
```
Although we don't currently have a task type that is owned by an individual when it is first created, there is a possibility of that happening in the future (especially if we add the ability for user to create personal tasks).