### PR TITLE
Closes AgileVentures/MetPlus_tracker#366

### DIFF
--- a/app/assets/javascripts/pusher.js.erb
+++ b/app/assets/javascripts/pusher.js.erb
@@ -55,12 +55,14 @@ var PusherControl = {
             "' target='_blank'>" + data.js_name + "</a>" +
             " has been assigned to you as Job Developer");
       }
-      // Process event if I am logged in and I am the job seeker
-      if (parseInt(Cookies('user_id')) === data.js_user_id) {
-        Notification.info_notification(data.jd_name +
-            ' has been assigned to you as your ' +
-            data.agency_name + ' Job Developer.');
-      }
+
+      PusherControl.notify_job_seeker(data.js_user_id, data.jd_name, data.agency_name,
+                        ' Job Developer.');
+    });
+
+    channel.bind('jd_self_assigned_js', function(data) {
+      PusherControl.notify_job_seeker(data.js_user_id, data.jd_name, data.agency_name,
+                        ' Job Developer.');
     });
 
     channel.bind('jobseeker_assigned_cm', function(data) {
@@ -71,12 +73,14 @@ var PusherControl = {
             "' target='_blank'>" + data.js_name + "</a>" +
             " has been assigned to you as Case Manager");
       }
-      // Process event if I am logged in and I am the job seeker
-      if (parseInt(Cookies('user_id')) === data.js_user_id) {
-        Notification.info_notification(data.cm_name +
-            ' has been assigned to you as your ' +
-            data.agency_name + ' Case Manager.');
-      }
+
+      PusherControl.notify_job_seeker(data.js_user_id, data.cm_name, data.agency_name,
+                        ' Case Manager.');
+    });
+
+    channel.bind('cm_self_assigned_js', function(data) {
+      PusherControl.notify_job_seeker(data.js_user_id, data.cm_name, data.agency_name,
+                        ' Case Manager.');
     });
 
     channel.bind('job_posted', function(data) {
@@ -88,6 +92,13 @@ var PusherControl = {
             " posted for company: " + data.company_name);
       }
     });
+  },
+  notify_job_seeker: function (user_id, agency_person_name, agency, role_str) {
+    // Process event if I am logged in and I am the job seeker
+    if (parseInt(Cookies('user_id')) === user_id) {
+      Notification.info_notification(agency_person_name +
+          ' has been assigned to you as your ' + agency + role_str);
+    }
   }
 };
 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -77,7 +77,7 @@ class JobsController < ApplicationController
 			flash[:notice] = "#{@job.title} has been created successfully."
 
       obj = Struct.new(:job, :agency)
-      Event.evt_job_posted(:JOB_POSTED, obj.new(@job, current_agency))
+      Event.create(:JOB_POSTED, obj.new(@job, current_agency))
 
 			redirect_to jobs_path
 		else

--- a/app/jobs/job_seeker_email_job.rb
+++ b/app/jobs/job_seeker_email_job.rb
@@ -3,11 +3,11 @@ class JobSeekerEmailJob < ActiveJob::Base
 
   def perform(evt_type, job_seeker, agency_person)
     case evt_type
-    when Event::EVT_TYPE[:JS_ASSIGN_JD]
+    when Event::EVT_TYPE[:JD_ASSIGNED_JS], Event::EVT_TYPE[:JD_SELF_ASSIGN_JS]
       JobSeekerMailer.job_developer_assigned(job_seeker,
                                              agency_person).deliver_later
 
-    when Event::EVT_TYPE[:JS_ASSIGN_CM]
+    when Event::EVT_TYPE[:CM_ASSIGNED_JS], Event::EVT_TYPE[:CM_SELF_ASSIGN_JS]
       JobSeekerMailer.case_manager_assigned(job_seeker,
                                             agency_person).deliver_later
 

--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -12,10 +12,10 @@ class NotifyEmailJob < ActiveJob::Base
     when Event::EVT_TYPE[:JS_APPLY]
       AgencyMailer.job_seeker_applied(email_addresses, evt_obj).deliver_later
 
-    when Event::EVT_TYPE[:JS_ASSIGN_JD]
+    when Event::EVT_TYPE[:JD_ASSIGNED_JS]
       AgencyMailer.job_seeker_assigned_jd(email_addresses, evt_obj).deliver_later
 
-    when Event::EVT_TYPE[:JS_ASSIGN_CM]
+    when Event::EVT_TYPE[:CM_ASSIGNED_JS]
       AgencyMailer.job_seeker_assigned_cm(email_addresses, evt_obj).deliver_later
 
     when Event::EVT_TYPE[:JOB_POSTED]

--- a/features/event_management.feature
+++ b/features/event_management.feature
@@ -102,7 +102,7 @@ Scenario: Company registration request in PETS
   And I should see "Review company registration"
 
 @selenium
-Scenario: Job developer assigned to job seeker
+Scenario: Job developer assigned to job seeker by agency admin
   When I am in Job Seeker's browser
   Given I am on the home page
   And I login as "sam@gmail.com" with password "qwerty123"
@@ -141,7 +141,7 @@ Scenario: Job developer assigned to job seeker
   Then they should see "Sam Seeker" after "Name"
 
 @selenium
-Scenario: Case manager assigned to job seeker
+Scenario: Case manager assigned to job seeker by agency admin
   When I am in Job Seeker's browser
   Given I am on the home page
   And I login as "sam@gmail.com" with password "qwerty123"
@@ -178,3 +178,53 @@ Scenario: Case manager assigned to job seeker
   Then they should see "A job seeker has been assigned to you as Case Manager:" in the email body
   When "jane@metplus.org" follows "Sam Seeker" in the email
   Then they should see "Sam Seeker" after "Name"
+
+@selenium
+Scenario: Job developer assigns self to job seeker
+  When I am in Job Seeker's browser
+  Given I am on the home page
+  And I login as "sam@gmail.com" with password "qwerty123"
+  Then I should see "Signed in successfully."
+  When I am in Job Developer's browser
+  Given I am on the home page
+  And I login as "dave@metplus.org" with password "qwerty123"
+  Then I should see "Signed in successfully."
+  And I should see "Seeker, Sam" after "Job Seekers without a Job Developer"
+  And I click the "Seeker, Sam" link
+  And I wait 1 second
+  And I should see "Assign Myself"
+  And I click the "Assign Myself" button
+  And I wait 1 second
+  And I should see "Dave Developer" after "Job Developer"
+  And I should not see "Assign Myself"
+  Then I am in Job Seeker's browser
+  And I should see "Dave Developer has been assigned to you as your MetPlus Job Developer"
+  And "sam@gmail.com" should receive an email with subject "Job developer assigned"
+  When "sam@gmail.com" opens the email
+  Then they should see "Dave Developer" in the email body
+  And they should see "has been assigned to you as your MetPlus Job Developer" in the email body
+
+@selenium
+Scenario: Case manager assigns self to job seeker
+  When I am in Job Seeker's browser
+  Given I am on the home page
+  And I login as "sam@gmail.com" with password "qwerty123"
+  Then I should see "Signed in successfully."
+  When I am in Case Manager's browser
+  Given I am on the home page
+  And I login as "jane@metplus.org" with password "qwerty123"
+  Then I should see "Signed in successfully."
+  And I should see "Seeker, Sam" after "Job Seekers without a Case Manager"
+  And I click the "Seeker, Sam" link
+  And I wait 1 second
+  And I should see "Assign Myself"
+  And I click the "Assign Myself" button
+  And I wait 1 second
+  And I should see "Jane Jones" after "Case Manager"
+  And I should not see "Assign Myself"
+  Then I am in Job Seeker's browser
+  And I should see "Jane Jones has been assigned to you as your MetPlus Case Manager"
+  And "sam@gmail.com" should receive an email with subject "Case manager assigned"
+  When "sam@gmail.com" opens the email
+  Then they should see "Jane Jones" in the email body
+  And they should see "has been assigned to you as your MetPlus Case Manager" in the email body

--- a/spec/jobs/job_seeker_email_job_spec.rb
+++ b/spec/jobs/job_seeker_email_job_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe JobSeekerEmailJob, type: :job do
 
   it 'job developer assigned to job seeker event' do
     expect{ JobSeekerEmailJob.set(wait: Event.delay_seconds.seconds).
-                 perform_later(Event::EVT_TYPE[:JS_ASSIGN_JD],
+                 perform_later(Event::EVT_TYPE[:JD_ASSIGNED_JS],
                  job_seeker, job_developer) }.
       to change(Delayed::Job, :count).by(+1)
   end
 
   it 'case manager assigned to job seeker event' do
     expect{ JobSeekerEmailJob.set(wait: Event.delay_seconds.seconds).
-                 perform_later(Event::EVT_TYPE[:JS_ASSIGN_CM],
+                 perform_later(Event::EVT_TYPE[:CM_ASSIGNED_JS],
                  job_seeker, case_manager) }.
       to change(Delayed::Job, :count).by(+1)
   end

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe NotifyEmailJob, type: :job do
   it 'job seeker assigned to job developer event' do
     expect{ NotifyEmailJob.set(wait: Event.delay_seconds.seconds).
                  perform_later('job_developer@gmail.com',
-                 Event::EVT_TYPE[:JS_ASSIGN_JD],
+                 Event::EVT_TYPE[:JD_ASSIGNED_JS],
                  {name: 'Joe Newseeker', id: 1}) }.
       to change(Delayed::Job, :count).by(+1)
   end
@@ -50,7 +50,7 @@ RSpec.describe NotifyEmailJob, type: :job do
   it 'job seeker assigned to case manager event' do
     expect{ NotifyEmailJob.set(wait: Event.delay_seconds.seconds).
                  perform_later('case_manager@gmail.com',
-                 Event::EVT_TYPE[:JS_ASSIGN_CM],
+                 Event::EVT_TYPE[:CM_ASSIGNED_JS],
                  {name: 'Joe Newseeker', id: 1}) }.
       to change(Delayed::Job, :count).by(+1)
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Event, type: :model do
   describe 'jobseeker_assigned_jd event' do
 
     it 'triggers Pusher messages to job developer and job seeker' do
-      Event.create(:JS_ASSIGN_JD, evt_obj_jd)
+      Event.create(:JD_ASSIGNED_JS, evt_obj_jd)
       expect(Pusher).to have_received(:trigger).
                     with('pusher_control',
                          'jobseeker_assigned_jd',
@@ -133,7 +133,7 @@ RSpec.describe Event, type: :model do
     end
 
     it 'sends event notification emails to job developer and job seeker' do
-      expect { Event.create(:JS_ASSIGN_JD, evt_obj_jd) }.
+      expect { Event.create(:JD_ASSIGNED_JS, evt_obj_jd) }.
                     to change(all_emails, :count).by(+2)
     end
 
@@ -142,7 +142,7 @@ RSpec.describe Event, type: :model do
   describe 'jobseeker_assigned_cm event' do
 
     it 'triggers Pusher messages to case manager and job seeker' do
-      Event.create(:JS_ASSIGN_CM, evt_obj_cm)
+      Event.create(:CM_ASSIGNED_JS, evt_obj_cm)
       expect(Pusher).to have_received(:trigger).
                     with('pusher_control',
                          'jobseeker_assigned_cm',
@@ -155,7 +155,7 @@ RSpec.describe Event, type: :model do
     end
 
     it 'sends event notification emails to case manager and job seeker' do
-      expect { Event.create(:JS_ASSIGN_CM, evt_obj_cm) }.
+      expect { Event.create(:CM_ASSIGNED_JS, evt_obj_cm) }.
                     to change(all_emails, :count).by(+2)
     end
   end
@@ -176,6 +176,42 @@ RSpec.describe Event, type: :model do
 
     it 'sends event notification email' do
       expect { Event.create(:JOB_POSTED, evt_obj_jobpost) }.
+                    to change(all_emails, :count).by(+1)
+    end
+  end
+
+  describe 'jd_self_assigned_js event' do
+
+    it 'triggers Pusher message to job seeker' do
+      Event.create(:JD_SELF_ASSIGN_JS, evt_obj_jd)
+      expect(Pusher).to have_received(:trigger).
+                    with('pusher_control',
+                         'jd_self_assigned_js',
+                         {js_user_id: job_seeker.user.id,
+                          jd_name: job_developer.full_name(last_name_first: false),
+                          agency_name: job_developer.agency.name})
+    end
+
+    it 'sends event notification email to job seeker' do
+      expect { Event.create(:JD_SELF_ASSIGN_JS, evt_obj_jd) }.
+                    to change(all_emails, :count).by(+1)
+    end
+  end
+
+  describe 'cm_self_assigned_js event' do
+
+    it 'triggers Pusher message to job seeker' do
+      Event.create(:CM_SELF_ASSIGN_JS, evt_obj_cm)
+      expect(Pusher).to have_received(:trigger).
+                    with('pusher_control',
+                         'cm_self_assigned_js',
+                         {js_user_id: job_seeker.user.id,
+                          cm_name: case_manager.full_name(last_name_first: false),
+                          agency_name: case_manager.agency.name})
+    end
+
+    it 'sends event notification email to job seeker' do
+      expect { Event.create(:CM_SELF_ASSIGN_JS, evt_obj_jd) }.
                     to change(all_emails, :count).by(+1)
     end
   end


### PR DESCRIPTION
A job seeker is to be notified when a job developer or a case manager has been assigned to him/her.

This happens when the assignment is done by an agency admin.

However, this notification is not happening when the assignment is via self-assignment by the JD or CM (that is, the JD or CM clicks the 'Assign Myself' button in the job seeker 'show' view (in '_assigned_agency_person.html.haml').

To fix:

- [ ] models/event.rb
  - Create two new event types:
    - JD_SELF_ASSIGN_JS
    - CM_SELF_ASSIGN_JS

  - For greater clarity, rename current events:
    - JS_ASSIGN_JD -> JD_ASSIGNED_JS
    - JS_ASSIGN_CM -> CM_ASSIGNED_JS

- [ ] controllers/agency_person.rb
  - Call the new Event methods in assign_job_seeker

- [ ] pusher.js.erb
  - add handlers for the two new events

- [ ]  job_seeker_email_job.rb
  - add logic for two new events
  
- [ ] job_seeker_mailer.rb
  - add logic to send email for each of two new events

- [ ] Cucumber tests
  - event_management.feature
    - Scenario: Job developer assigns self to job seeker
    - Scenario: Case manager assigns self to job seeker

- [ ] Rspec tests
  - event_spec.rb
    - describe 'jd_self_assigned_js event' do
    - describe 'cm_self_assigned_js event' do
