### PR TITLE
Closes AgileVentures/MetPlus_tracker#369

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,9 +29,14 @@ class Job < ActiveRecord::Base
   validates_length_of   :description, maximum: 10000
   validates_presence_of :company_id
   validates_presence_of :company_person_id, allow_nil: true
-  #validates_presence_of :job_category_id
   scope :new_jobs, ->(given_time) {where("created_at > ?", given_time)}
   scope :find_by_company, ->(company) {where(:company => company)}
+
+  STATUS = {ACTIVE:  'active',
+            FILLED:  'filled',
+            REVOKED: 'revoked'}
+  validates_inclusion_of :status, :in => STATUS.values,
+       :message => "must be one of: #{STATUS.values.join(', ')}"
 
   def number_applicants
     job_applications.size

--- a/db/migrate/20160712184530_add_status_to_job.rb
+++ b/db/migrate/20160712184530_add_status_to_job.rb
@@ -1,0 +1,6 @@
+class AddStatusToJob < ActiveRecord::Migration
+  def change
+    add_column :jobs, :status, :string,
+                      default: Job::STATUS[:ACTIVE]
+  end
+end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     company_job_id "KRKE12"
     shift 'Day'
     fulltime true
+    status Job::STATUS[:ACTIVE]
   end
 
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Job, type: :model do
   describe 'Associations' do
     it { is_expected.to belong_to :company }
     it { is_expected.to belong_to :company_person }
-    it  { is_expected.to belong_to :address }
+    it { is_expected.to belong_to :address }
     it { is_expected.to belong_to :job_category }
     it { is_expected.to have_many(:job_skills).dependent(:destroy) }
     it { is_expected.to accept_nested_attributes_for(:job_skills).
@@ -36,9 +36,9 @@ RSpec.describe Job, type: :model do
     it { is_expected.to have_db_column :shift}
     it { is_expected.to have_db_column :fulltime}
     it { is_expected.to have_db_column :company_id }
-
     it { is_expected.to have_db_column :company_person_id }
     it { is_expected.to have_db_column :address_id }
+    it { is_expected.to have_db_column :status }
   end
 
   describe 'Validations' do
@@ -51,7 +51,10 @@ RSpec.describe Job, type: :model do
     it { should allow_value('', nil).for(:fulltime).on(:create) }
     it { is_expected.to validate_presence_of :company_id }
     xit { is_expected.to validate_presence_of :company_person_id }
-    it { is_expected.to validate_inclusion_of(:shift).in_array(%w[Day Evening Morning])}
+    it { is_expected.to validate_inclusion_of(:shift).
+                                      in_array(%w[Day Evening Morning]) }
+    it { is_expected.to validate_inclusion_of(:status).
+                                      in_array(Job::STATUS.values) }
   end
 
   describe 'Class methods' do
@@ -103,7 +106,7 @@ RSpec.describe Job, type: :model do
       end
     end
   end
-  describe 'Create Job method(AR model and CruncherService)' do
+  describe 'Create Job method (AR model and CruncherService)' do
 
     before(:each) do
       stub_request(:post, CruncherService.service_url + '/authenticate').
@@ -111,7 +114,7 @@ RSpec.describe Job, type: :model do
           :headers => {'Content-Type'=> 'application/json'})
     end
 
-    it 'is succeeds with all parameters' do
+    it 'succeeds with all parameters' do
 
       stub_request(:post, CruncherService.service_url + '/job/create').
           to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,


### PR DESCRIPTION
**Story**: add states to Job model

The states are defined in the first table here: http://www.agileventures.org/projects/metplus/documents/system-behavior

**Implementation**:

- Add to the model, e.g.
    STATUS = {ACTIVE: 'active',
          FILLED: 'filled',
          REVOKED: 'revoked'}
(note that job 'state' is called 'status' here since a job has_one address, and an address has a 'state' field - thus to avoid ambiguous SQL statements we use 'status'.

- Create a migration file to add field to DB

- Add tests to job_spec.rb

- Add 'status' field to Job factory