### PR TITLE
Closes AgileVentures/MetPlus_tracker#308

### DIFF
--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -9,7 +9,7 @@ class Agency < ActiveRecord::Base
   validates :phone, :phone => true
   validates :email, :email => true
   validates :website, :website => true
-  validates :fax, :phone => true, allow_blank: true
+  validates :fax, :fax => true, allow_blank: true
 
   def self.agency_admins(agency)
     find_users_with_role(agency, AgencyRole::ROLE[:AA])

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -9,7 +9,7 @@ class Agency < ActiveRecord::Base
   validates :phone, :phone => true
   validates :email, :email => true
   validates :website, :website => true
-  validates :fax, :fax => true, allow_blank: true
+  validates :fax, :phone => true, allow_blank: true
 
   def self.agency_admins(agency)
     find_users_with_role(agency, AgencyRole::ROLE[:AA])

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -15,7 +15,7 @@ class Company < ActiveRecord::Base
   validates_uniqueness_of :ein, case_sensitive: false,
                   message: 'has already been registered'
   validates :phone, :phone => true
-  validates :fax, :phone => true, allow_blank: true
+  validates :fax, :fax => true, allow_blank: true
   validates :email, :email => true
   validates :website, :website => true
   validates_presence_of :name

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -15,7 +15,7 @@ class Company < ActiveRecord::Base
   validates_uniqueness_of :ein, case_sensitive: false,
                   message: 'has already been registered'
   validates :phone, :phone => true
-  validates :fax, :fax => true, allow_blank: true
+  validates :fax, :phone => true, allow_blank: true
   validates :email, :email => true
   validates :website, :website => true
   validates_presence_of :name

--- a/app/validators/fax_validator.rb
+++ b/app/validators/fax_validator.rb
@@ -1,0 +1,9 @@
+class FaxValidator < ActiveModel::EachValidator
+  def validate_each(object, attribute, value)
+    return if value == nil
+    reg = /^(1-)?((\(\d{3}\))|\d{3})( |-)?\d{3}( |-)?\d{4}( ?x\d+)?$/
+    unless value.match reg
+      object.errors[attribute] << (options[:message] || 'Invalid format')
+    end
+  end
+end

--- a/app/validators/fax_validator.rb
+++ b/app/validators/fax_validator.rb
@@ -1,9 +1,0 @@
-class FaxValidator < ActiveModel::EachValidator
-  def validate_each(object, attribute, value)
-    return if value == nil
-    reg = /^(1-)?((\(\d{3}\))|\d{3})( |-)?\d{3}( |-)?\d{4}( ?x\d+)?$/
-    unless value.match reg
-      object.errors[attribute] << (options[:message] || 'Invalid format')
-    end
-  end
-end

--- a/app/validators/phone_validator.rb
+++ b/app/validators/phone_validator.rb
@@ -1,7 +1,7 @@
 class PhoneValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     return if value == nil
-    reg = /^(\+\d{1,3} )?\(?\d{3}\)?( |-)?\d{3}( |-)?\d{4}$/
+    reg = /^(1-)?((\(\d{3}\))|\d{3})( |-)?\d{3}( |-)?\d{4}( ?x\d+)?$/
     unless value.match reg
       object.errors[attribute] << (options[:message] || 'incorrect format')
     end

--- a/app/views/agencies/_form.html.haml
+++ b/app/views/agencies/_form.html.haml
@@ -21,7 +21,8 @@
   .form-group
     = label :agency, :fax, 'Fax', class: 'control-label col-sm-2'
     .col-sm-6
-      = phone_field :agency, :fax, size: 30, class: 'form-control'
+      = phone_field :agency, :fax, size: 30, class: 'form-control',
+        placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
   .form-group
     = label :agency, :email, 'Email', class: 'control-label col-sm-2'

--- a/app/views/agencies/_form.html.haml
+++ b/app/views/agencies/_form.html.haml
@@ -16,7 +16,8 @@
   .form-group
     = label :agency, :phone, 'Phone', class: 'control-label col-sm-2'
     .col-sm-6
-      = phone_field :agency, :phone, size: 30, class: 'form-control'
+      = phone_field :agency, :phone, size: 30, class: 'form-control',
+      placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
   .form-group
     = label :agency, :fax, 'Fax', class: 'control-label col-sm-2'

--- a/app/views/companies/_subform.html.haml
+++ b/app/views/companies/_subform.html.haml
@@ -12,7 +12,8 @@
   .col-sm-2.control-label
     = label :company, :phone, 'Phone'
   .col-sm-4
-    = @address_form.phone_field :phone, size: 30, class: 'form-control'
+    = @address_form.phone_field :phone, size: 30, class: 'form-control',
+    placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
 .form-group
   .col-sm-2.control-label

--- a/app/views/companies/_subform.html.haml
+++ b/app/views/companies/_subform.html.haml
@@ -25,7 +25,8 @@
   .col-sm-1.control-label
     = label :company, :fax, 'Fax'
   .col-sm-4
-    = @address_form.phone_field :fax, size: 30, class: 'form-control'
+    = @address_form.phone_field :fax, size: 30, class: 'form-control',
+    placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
 .form-group
   .col-sm-2.control-label

--- a/app/views/company_registrations/_form.html.haml
+++ b/app/views/company_registrations/_form.html.haml
@@ -28,7 +28,8 @@
     .form-group
       = company_person_f.label :phone, 'Contact Phone', class: 'control-label col-sm-2'
       .col-sm-6
-        = company_person_f.phone_field :phone, size: 30, class: 'form-control'
+        = company_person_f.phone_field :phone, size: 30, class: 'form-control',
+        placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
     .form-group
       = company_person_f.label :email, 'Contact Email', class: 'control-label col-sm-2'

--- a/app/views/users/_subform.html.haml
+++ b/app/views/users/_subform.html.haml
@@ -14,7 +14,8 @@
 .form-group
 	=@user_form.label :phone, 'Phone', class:'control-label col-sm-2'
 	.col-sm-6
-		=@user_form.text_field :phone, size: 30, class:'form-control'
+		=@user_form.text_field :phone, size: 30, class:'form-control',
+		placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
 .form-group
 

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Agency, type: :model do
   end
 
   describe 'Validations' do
-    describe 'Validate presence'
+    describe 'Validate presence' do
       it { is_expected.to validate_presence_of :name }
       it { is_expected.to validate_length_of(:name).is_at_most(100) }
       it { is_expected.to validate_presence_of :website }
@@ -134,5 +134,4 @@ RSpec.describe Agency, type: :model do
         to eq [person1.email, person2.email, person3.email]
     end
   end
-
 end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Agency, type: :model do
 
     describe 'phone' do
        subject {FactoryGirl.build(:agency)}
-       it { should_not allow_value('asd', '123456', '123 123 12345',
-               '123 1231  1234', '1123 123 1234', ' 123 123 1234').for(:phone)}
-
-       it { should allow_value('+1 123 123 1234', '123 123 1234',
-               '(123) 123 1234', '1231231234', '+1 (123) 1231234').for(:phone)}
+       it { should_not allow_value('+1 123 123 1234', 'asd', '123456', '123 123 12345',
+               '123 1231  1234', '1123 123 1234', ' 123 123 1234', 
+               '(234 1234 1234', '786) 1243 3578').for(:phone)}
+       it { should allow_value('123 123 1234', '(123) 123 1234', '1231231234',
+               '1-910-123-9158 x2851', '1-872-928-5886', '833-638-6551 x16825').for(:phone)}
      end
 
      describe 'fax' do

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -24,12 +24,53 @@ RSpec.describe Agency, type: :model do
   end
 
   describe 'Validations' do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_length_of(:name).is_at_most(100) }
-    it { is_expected.to validate_presence_of :website }
-    it { is_expected.to validate_length_of(:website).is_at_most(200) }
-    it { is_expected.to validate_presence_of :phone }
-    it { is_expected.to validate_presence_of :email }
+    describe 'Validate presence'
+      it { is_expected.to validate_presence_of :name }
+      it { is_expected.to validate_length_of(:name).is_at_most(100) }
+      it { is_expected.to validate_presence_of :website }
+      it { is_expected.to validate_length_of(:website).is_at_most(200) }
+      it { is_expected.to validate_presence_of :phone }
+      it { is_expected.to validate_presence_of :email }
+    end
+
+    describe 'phone' do
+       subject {FactoryGirl.build(:agency)}
+       it { should_not allow_value('asd', '123456', '123 123 12345',
+               '123 1231  1234', '1123 123 1234', ' 123 123 1234').for(:phone)}
+
+       it { should allow_value('+1 123 123 1234', '123 123 1234',
+               '(123) 123 1234', '1231231234', '+1 (123) 1231234').for(:phone)}
+     end
+
+     describe 'fax' do
+       subject {FactoryGirl.build(:agency)}
+       it { should_not allow_value('+1 123 123 1234', 'asd', '123456', '123 123 12345',
+               '123 1231  1234', '1123 123 1234', ' 123 123 1234', 
+               '(234 1234 1234', '786) 1243 3578').for(:fax)}
+
+       it { should allow_value('123 123 1234', '(123) 123 1234', '1231231234',
+               '1-910-123-9158 x2851', '1-872-928-5886', '833-638-6551 x16825').for(:fax)}
+     end
+
+     describe 'Email' do
+       subject {FactoryGirl.build(:agency)}
+       it { should_not allow_value('asd', 'john@company').for(:email)}
+       it { should allow_value('johndoe@company.com').for(:email)}
+     end
+
+
+     describe 'Website' do
+       subject {FactoryGirl.build(:agency)}
+       it { should_not allow_value('asd', 'ftp://company.com', 'http:',
+                 'http://','https',  'https:', 'https://',
+                 'http://place.com###Bammm').for(:website)}
+
+       it { should allow_value('http://company.com',
+                               'https://company.com',
+                               'http://w.company.com/info',
+                               'https://comp.com:10/test/1/wasd',
+                               'http://company.com/').for(:website)}
+     end
   end
 
   describe 'Agency model' do

--- a/spec/models/company_person_spec.rb
+++ b/spec/models/company_person_spec.rb
@@ -32,10 +32,11 @@ describe CompanyPerson, type: :model do
     it { should_not allow_value('abc', 'abc@abc', 'abcdefghjjkll').for(:email)}
     it { is_expected.to validate_presence_of :first_name }
     it { is_expected.to validate_presence_of :last_name }
-    it { should_not allow_value('asd', '123456', '123 123 12345',
-        '123 1231 1234', '1123 123 1234', ' 123 123 1234').for(:phone)}
-    it { should allow_value('+1 123 123 1234', '123 123 1234',
-        '(123) 123 1234', '1231231234', '+1 (123) 1231234').for(:phone)}
+    it { should_not allow_value('+1 123 123 1234', 'asd', '123456', '123 123 12345',
+               '123 1231  1234', '1123 123 1234', ' 123 123 1234', 
+               '(234 1234 1234', '786) 1243 3578').for(:phone)}
+    it { should allow_value('123 123 1234', '(123) 123 1234', '1231231234',
+               '1-910-123-9158 x2851', '1-872-928-5886', '833-638-6551 x16825').for(:phone)}
   end
 
   context "#acting_as?" do

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe Company, type: :model do
 
      describe 'phone' do
        subject {FactoryGirl.build(:company)}
-       it { should_not allow_value('asd', '123456', '123 123 12345',
-               '123 1231  1234', '1123 123 1234', ' 123 123 1234').for(:phone)}
-
-       it { should allow_value('+1 123 123 1234', '123 123 1234',
-               '(123) 123 1234', '1231231234', '+1 (123) 1231234').for(:phone)}
+       it { should_not allow_value('+1 123 123 1234', 'asd', '123456', '123 123 12345',
+               '123 1231  1234', '1123 123 1234', ' 123 123 1234', 
+               '(234 1234 1234', '786) 1243 3578').for(:phone)}
+       it { should allow_value('123 123 1234', '(123) 123 1234', '1231231234',
+               '1-910-123-9158 x2851', '1-872-928-5886', '833-638-6551 x16825').for(:phone)}
      end
 
      describe 'fax' do

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -53,11 +53,12 @@ RSpec.describe Company, type: :model do
 
      describe 'fax' do
        subject {FactoryGirl.build(:company)}
-       it { should_not allow_value('asd', '123456', '123 123 12345',
-               '123 1231  1234', '1123 123 1234', ' 123 123 1234').for(:fax)}
+       it { should_not allow_value('+1 123 123 1234', 'asd', '123456', '123 123 12345',
+               '123 1231  1234', '1123 123 1234', ' 123 123 1234', 
+               '(234 1234 1234', '786) 1243 3578').for(:fax)}
 
-       it { should allow_value('+1 123 123 1234', '123 123 1234',
-               '(123) 123 1234', '1231231234', '+1 (123) 1231234').for(:fax)}
+       it { should allow_value('123 123 1234', '(123) 123 1234', '1231231234',
+               '1-910-123-9158 x2851', '1-872-928-5886', '833-638-6551 x16825').for(:fax)}
      end
 
      describe 'Email' do


### PR DESCRIPTION
Fixed the regex in app/validators/phone_validator.rb to reflect the necessary changes.

Since the validators for phone and fax essentially do the same thing, removed the fax_validator.rb and made sure both the phone and fax fields in the agency, company and user models are using the phone_validator.rb

Added placeholders in the forms to help users input valid phone numbers.

Made changes in the test files so that phone numbers are validated correctly.