### PR TITLE
Closes AgileVentures/MetPlus_tracker#337

### DIFF
--- a/app/controllers/agency_admin_controller.rb
+++ b/app/controllers/agency_admin_controller.rb
@@ -34,7 +34,7 @@ class AgencyAdminController < ApplicationController
         @job_categories = JobCategory.order(:name).
                     page(params[:job_categories_page]).per_page(10)
 
-        render partial: 'job_specialities', object: @job_categories,
+        render partial: 'job_specialties', object: @job_categories,
                 locals: {data_type:  'job_categories',
                          partial_id: 'job_categories_table',
                          show_property_path:   :job_category_path,

--- a/app/controllers/agency_admin_controller.rb
+++ b/app/controllers/agency_admin_controller.rb
@@ -34,7 +34,7 @@ class AgencyAdminController < ApplicationController
         @job_categories = JobCategory.order(:name).
                     page(params[:job_categories_page]).per_page(10)
 
-        render partial: 'job_properties', object: @job_categories,
+        render partial: 'job_specialities', object: @job_categories,
                 locals: {data_type:  'job_categories',
                          partial_id: 'job_categories_table',
                          show_property_path:   :job_category_path,
@@ -43,7 +43,7 @@ class AgencyAdminController < ApplicationController
         @skills = Skill.order(:name).
                     page(params[:skills_page]).per_page(10)
 
-        render partial: 'job_properties', object: @skills,
+        render partial: 'job_skills', object: @skills,
                 locals: {data_type:  'skills',
                          partial_id: 'skills_table',
                          show_property_path:   :skill_path,

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -8,4 +8,9 @@ class Skill < ActiveRecord::Base
   has_many :job_skills, dependent: :destroy
   
   has_many :jobs, through: :job_skills
+
+  def has_job?
+  	jobs.any?
+  end
+  
 end

--- a/app/views/agency_admin/_job_skills.html.haml
+++ b/app/views/agency_admin/_job_skills.html.haml
@@ -1,0 +1,26 @@
+%div(id="#{partial_id}")
+  %table.table.table-hover
+    %thead
+      %tr
+        %th
+          %strong Name
+        %th
+          %strong Description
+        %th
+          %strong Delete
+    %tbody
+      - job_skills.each do |job_prop|
+        %tr
+          %td
+            = link_to "#{job_prop.name}", send(show_property_path, job_prop), method: :edit
+          %td
+            = job_prop.description
+          %td
+            - if job_prop.has_job?
+              %span.glyphicon.glyphicon-remove
+            - else
+              = link_to send(delete_property_path, job_prop), method: :delete do
+                %span.glyphicon.glyphicon-remove          
+
+  = will_paginate job_skills, param_name: "#{data_type}_page",
+                     params: {data_type: data_type}

--- a/app/views/agency_admin/_job_specialities.html.haml
+++ b/app/views/agency_admin/_job_specialities.html.haml
@@ -9,7 +9,7 @@
         %th
           %strong Delete
     %tbody
-      - job_properties.each do |job_prop|
+      - job_specialities.each do |job_prop|
         %tr
           %td
             = link_to "#{job_prop.name}", send(show_property_path, job_prop), method: :edit
@@ -17,7 +17,7 @@
             = job_prop.description
           %td
             = link_to send(delete_property_path, job_prop), method: :delete do
-              %span.glyphicon.glyphicon-remove
+              %span.glyphicon.glyphicon-remove          
 
-  = will_paginate job_properties, param_name: "#{data_type}_page",
+  = will_paginate job_specialities, param_name: "#{data_type}_page",
                      params: {data_type: data_type}

--- a/app/views/agency_admin/_job_specialties.html.haml
+++ b/app/views/agency_admin/_job_specialties.html.haml
@@ -9,7 +9,7 @@
         %th
           %strong Delete
     %tbody
-      - job_specialities.each do |job_prop|
+      - job_specialties.each do |job_prop|
         %tr
           %td
             = link_to "#{job_prop.name}", send(show_property_path, job_prop), method: :edit
@@ -19,5 +19,5 @@
             = link_to send(delete_property_path, job_prop), method: :delete do
               %span.glyphicon.glyphicon-remove          
 
-  = will_paginate job_specialities, param_name: "#{data_type}_page",
+  = will_paginate job_specialties, param_name: "#{data_type}_page",
                      params: {data_type: data_type}

--- a/app/views/agency_admin/job_properties.html.haml
+++ b/app/views/agency_admin/job_properties.html.haml
@@ -2,14 +2,14 @@
 
 .row
   .col-sm-3
-    %h4 Job Specialities
+    %h4 Job Specialties
 
   - if @job_categories.empty?
     .col-sm-3
-      %h5 There are no job specialities.
+      %h5 There are no job specialties.
   - else
     .col-sm-9
-      = render partial: 'job_specialities', object: @job_categories,
+      = render partial: 'job_specialties', object: @job_categories,
                 locals: {data_type:  'job_categories',
                          partial_id: 'job_categories_table',
                          show_property_path:   :job_category_path,
@@ -17,10 +17,10 @@
     .clearfix
     .col-sm-3.col-sm-offset-3
       %a(id='toggle_job_categories' href='#job_categories_table' class='text-danger')
-        Hide Job Specialities
+        Hide Job Specialties
 
   .col-sm-3.col-sm-offset-3.table_action_button
-    - text_modal_button 'Add Job Speciality', 'add_job_category',
+    - text_modal_button 'Add Job Specialty', 'add_job_category',
                         'btn btn-primary btn-sm pull-right'
 
 .row

--- a/app/views/agency_admin/job_properties.html.haml
+++ b/app/views/agency_admin/job_properties.html.haml
@@ -2,14 +2,14 @@
 
 .row
   .col-sm-3
-    %h4 Job Specialties
+    %h4 Job Specialities
 
   - if @job_categories.empty?
     .col-sm-3
-      %h5 There are no job specialties.
+      %h5 There are no job specialities.
   - else
     .col-sm-9
-      = render partial: 'job_properties', object: @job_categories,
+      = render partial: 'job_specialities', object: @job_categories,
                 locals: {data_type:  'job_categories',
                          partial_id: 'job_categories_table',
                          show_property_path:   :job_category_path,
@@ -17,10 +17,10 @@
     .clearfix
     .col-sm-3.col-sm-offset-3
       %a(id='toggle_job_categories' href='#job_categories_table' class='text-danger')
-        Hide Job Specialties
+        Hide Job Specialities
 
   .col-sm-3.col-sm-offset-3.table_action_button
-    - text_modal_button 'Add Job Specialty', 'add_job_category',
+    - text_modal_button 'Add Job Speciality', 'add_job_category',
                         'btn btn-primary btn-sm pull-right'
 
 .row
@@ -32,7 +32,7 @@
       %h5 There are no job skills.
   - else
     .col-sm-9
-      = render partial: 'job_properties', object: @skills,
+      = render partial: 'job_skills', object: @skills,
                 locals: {data_type:  'skills',
                          partial_id: 'skills_table',
                          show_property_path:   :skill_path,

--- a/spec/controllers/agency_admin_controller_spec.rb
+++ b/spec/controllers/agency_admin_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe AgencyAdminController, type: :controller do
     it 'renders partial for job categories' do
       xhr :get, :job_properties, {job_categories_page: 2,
                       data_type: 'job_categories'}
-      expect(response).to render_template(partial: '_job_properties')
+      expect(response).to render_template(partial: '_job_specialities')
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/controllers/agency_admin_controller_spec.rb
+++ b/spec/controllers/agency_admin_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe AgencyAdminController, type: :controller do
     it 'renders partial for job categories' do
       xhr :get, :job_properties, {job_categories_page: 2,
                       data_type: 'job_categories'}
-      expect(response).to render_template(partial: '_job_specialities')
+      expect(response).to render_template(partial: '_job_specialties')
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
Remove ability to delete a skill when it is associated with a job.
The same template file was being used for both Job Specialities and Job Skills. Hence a new template file has been created for rendering Job Skills.