### PR TITLE
Closes AgileVentures/MetPlus_tracker#371

### DIFF
--- a/app/assets/javascripts/jobs.js
+++ b/app/assets/javascripts/jobs.js
@@ -14,5 +14,20 @@ $(function () {
               $('#address_select').html(data);
             }
           });
-    });
   });
+
+  
+  $('button[data-action="revoke"], #revoke_link').on('click', function() {
+    var id = $(this).attr('data-job-id');
+    var title = $(this).attr('data-job-title');
+    var companyJobId = $(this).attr('data-job-companyJobId');
+    
+    $('#revokeModal').find('#title').html('job title: ' + title);
+    $('#revokeModal').find('#company_job_id').html('company job id: ' + companyJobId);
+    $('#revokeModal').find('#confirm_revoke').attr('href','/jobs/' + id + '/revoke');
+    $('#revokeModal').modal();
+    
+  });
+ 
+
+});

--- a/app/assets/javascripts/jobs.js
+++ b/app/assets/javascripts/jobs.js
@@ -22,6 +22,7 @@ $(function () {
     var title = $(this).attr('data-job-title');
     var companyJobId = $(this).attr('data-job-companyJobId');
     
+    $('#revokeModal').find('.modal-title').html(title);
     $('#revokeModal').find('#title').html('job title: ' + title);
     $('#revokeModal').find('#company_job_id').html('company job id: ' + companyJobId);
     $('#revokeModal').find('#confirm_revoke').attr('href','/jobs/' + id + '/revoke');

--- a/app/assets/javascripts/pusher.js.erb
+++ b/app/assets/javascripts/pusher.js.erb
@@ -92,6 +92,16 @@ var PusherControl = {
             " posted for company: " + data.company_name);
       }
     });
+
+    channel.bind('job_revoked', function(data) {
+      // Process event if I am logged in and I am in notify list
+      if ($.inArray(parseInt(Cookies('user_id')), data.notify_list) != -1) {
+        Notification.info_notification('Job (' +
+            "<a href='/jobs/" + data.job_id +
+            "' target='_blank'>" + data.job_title + '</a>)' +
+            " revoked for company: " + data.company_name);
+      }
+    });
   },
   notify_job_seeker: function (user_id, agency_person_name, agency, role_str) {
     // Process event if I am logged in and I am the job seeker

--- a/app/assets/stylesheets/jobs.css.scss
+++ b/app/assets/stylesheets/jobs.css.scss
@@ -62,7 +62,7 @@ $state-danger-text: #a94442;
 	}
 }
 
-.btn.btn-primary.btn-xs#jobs-delete-link{
+.btn.btn-primary.btn-xs.jobs-revoke-button{
 	margin-left: 7px;
 	background: $light-blue;
 }

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -177,7 +177,7 @@ class JobsController < ApplicationController
 
 	def revoke
 		if @job.status == 'active' && @job.update(status: 'revoked')
-			flash[:alert] = "Job is revoked successfully"
+			flash[:alert] = "#{@job.title} is revoked successfully."
 			obj = Struct.new(:job, :agency)
 			Event.create(:JOB_REVOKED, obj.new(@job, Agency.first))
 		else

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -4,7 +4,7 @@ class JobsController < ApplicationController
   include JobApplicationsViewer
 
 	before_action :find_job,	only: [:show, :edit, :update, :destroy,
-                :applications, :applications_list]
+                :applications, :applications_list, :revoke]
 	before_action :authentication_for_post_or_edit, only: [:new, :edit, :create, :update, :destroy]
 	before_action :is_right_company_person, only: [:edit, :destroy, :update]
 	before_action :user_logged!, only: [:apply]
@@ -145,8 +145,15 @@ class JobsController < ApplicationController
 
 	def apply
 		@job = Job.find_by_id params[:job_id]
+
 		if @job == nil
 			flash[:alert] = "Unable to find the job the user is trying to apply to."
+			redirect_to jobs_url
+			return
+		end
+
+		if @job.status != 'active'
+			flash[:alert] = "Unable to apply. Job has either been filled or revoked."
 			redirect_to jobs_url
 			return
 		end
@@ -167,6 +174,18 @@ class JobsController < ApplicationController
 			redirect_to job_path(@job)
 		end
 	end
+
+	def revoke
+		if @job.status == 'active' && @job.update(status: 'revoked')
+			flash[:alert] = "Job is revoked successfully"
+			obj = Struct.new(:job, :agency)
+			Event.create(:JOB_REVOKED, obj.new(@job, Agency.first))
+		else
+			flash[:alert] = "Only active job can be revoked."
+		end
+		redirect_to jobs_path
+	end
+
 
 	private
 

--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -21,6 +21,8 @@ class NotifyEmailJob < ActiveJob::Base
     when Event::EVT_TYPE[:JOB_POSTED]
       AgencyMailer.job_posted(email_addresses, evt_obj).deliver_later
 
+    when Event::EVT_TYPE[:JOB_REVOKED]
+      AgencyMailer.job_revoked(email_addresses, evt_obj).deliver_later
     end
   end
 end

--- a/app/mailers/agency_mailer.rb
+++ b/app/mailers/agency_mailer.rb
@@ -24,6 +24,10 @@ class AgencyMailer < ApplicationMailer
     send_notification_mail(email_list, job, 'New Job Posted')
   end
 
+  def job_revoked(email_list, job)
+    send_notification_mail(email_list, job, 'Job Revoked')
+  end
+
   private
 
   def send_notification_mail(email_list, obj, obj_type)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,7 @@ class Event
               COMP_DENIED:   'company_registration_denied',
               JS_APPLY:      'jobseeker_applied',
               JOB_POSTED:    'job_posted',
+              JOB_REVOKED:   'job_revoked', 
               JD_ASSIGNED_JS:    'jobseeker_assigned_jd',
               CM_ASSIGNED_JS:    'jobseeker_assigned_cm',
               JD_SELF_ASSIGN_JS: 'jd_self_assigned_js',
@@ -41,6 +42,8 @@ class Event
       evt_js_apply(evt_obj)
     when :JOB_POSTED
       evt_job_posted(evt_obj)
+    when :JOB_REVOKED
+      evt_job_revoked(evt_obj)
     when :JD_ASSIGNED_JS
       evt_jd_assigned_js(evt_obj)
     when :CM_ASSIGNED_JS
@@ -242,6 +245,31 @@ class Event
       NotifyEmailJob.set(wait: delay_seconds.seconds).
                      perform_later(jd_emails,
                      EVT_TYPE[:JOB_POSTED],
+                     evt_obj.job)
+    end
+  end
+
+  def self.evt_job_revoked(evt_obj)
+    # evt_obj = struct(:job, :agency)
+    # Notify all job developers in agency (email and popup)
+
+    job_developers = Agency.job_developers(evt_obj.agency)
+
+    unless job_developers.empty?
+
+      jd_ids     = job_developers.collect {|jd| jd.user.id}
+      jd_emails  = job_developers.collect {|jd| jd.email}
+
+      Pusher.trigger('pusher_control',
+                     EVT_TYPE[:JOB_REVOKED],
+                     {job_id:       evt_obj.job.id,
+                      job_title:    evt_obj.job.title,
+                      company_name: evt_obj.job.company.name,
+                      notify_list:  jd_ids})
+
+      NotifyEmailJob.set(wait: delay_seconds.seconds).
+                     perform_later(jd_emails,
+                     EVT_TYPE[:JOB_REVOKED],
                      evt_obj.job)
     end
   end

--- a/app/views/agency_mailer/agency_notification.html.haml
+++ b/app/views/agency_mailer/agency_notification.html.haml
@@ -33,6 +33,11 @@
     A new job (
     = link_to @obj.title, job_url(id: @obj.id)
     ) has been posted for company: #{@obj.company.name}.
+
+  - elsif @obj_type == 'Job Revoked'
+    A job (
+    = link_to @obj.title, job_url(id: @obj.id)
+    ) has been revoked for company: #{@obj.company.name}.
 %p
   If you have any questions please contact the PETS administrator at:
   = mail_to("#{ENV['SMTP_USERNAME']}", 'PETS Admin',

--- a/app/views/jobs/_job.html.haml
+++ b/app/views/jobs/_job.html.haml
@@ -1,12 +1,18 @@
-%h4
-	=link_to job.title, job_path(job)
-%h5= job.company.name
-%small
-	= "#{time_ago_in_words(job.created_at, )} ago"
-	=render partial: 'modal', locals: {job: job}
-	-if pets_user.is_a?(CompanyPerson) || (pets_user.is_a?(AgencyPerson) && pets_user.is_job_developer?(pets_user.agency)) 
-		%button.btn.btn-primary.btn-xs.pull-right#jobs-delete-link{"data-target" => "#myModal",
-		 "data-toggle" => "modal", :type => "button"}
-			delete
-		=link_to "edit", edit_job_path(job), class: "pull-right btn btn-primary btn-xs", 
-		       id: "jobs-edit-link"
+%div{class: "well well-lg col-sm-offset-2 col-sm-8", id: "sub-list-id"}
+	%h4
+		=link_to job.title, job_path(job)
+		-if job.status == 'revoked' 
+			%span{class: 'label label-info'} Revoked
+	%h5= job.company.name
+	%small
+		= "#{time_ago_in_words(job.created_at, )} ago"
+		
+		-if job.status == 'active'
+			-if pets_user.is_a?(CompanyPerson) || (pets_user.is_a?(AgencyPerson) && pets_user.is_job_developer?(pets_user.agency)) 
+				=link_to "revoke", '#', data: { :toggle => 'modal', :target => '#revokeModal' }
+				=render partial: 'revoke_modal', locals: { job: job }
+				
+				%button.btn.btn-primary.btn-xs.pull-right(data-target="#revokeModal" data-toggle="modal" type="button")revoke
+				=render partial: 'revoke_modal', locals: { job: job }
+				=link_to "edit", edit_job_path(job), class: "pull-right btn btn-primary btn-xs", 
+				       id: "jobs-edit-link"

--- a/app/views/jobs/_job.html.haml
+++ b/app/views/jobs/_job.html.haml
@@ -9,6 +9,6 @@
 		
 	-if job.status == 'active'
 		-if pets_user.is_a?(CompanyPerson) || (pets_user.is_a?(AgencyPerson) && pets_user.is_job_developer?(pets_user.agency))
-			%button.btn.btn-primary.btn-xs.pull-right{ type: "button", data: { action: 'revoke', job: { id: "#{job.id}", title: "#{job.title}", companyJobId: "#{job.company_job_id}" } } }revoke
+			%button.btn.btn-primary.btn-xs.pull-right.jobs-revoke-button{ type: "button", data: { action: 'revoke', job: { id: "#{job.id}", title: "#{job.title}", companyJobId: "#{job.company_job_id}" } } }revoke
 			=link_to "edit", edit_job_path(job), class: "pull-right btn btn-primary btn-xs", 
 			       id: "jobs-edit-link"

--- a/app/views/jobs/_job.html.haml
+++ b/app/views/jobs/_job.html.haml
@@ -1,4 +1,4 @@
-%div{class: "well well-lg col-sm-offset-2 col-sm-8", id: "sub-list-id"}
+%div{class: "well well-lg col-sm-offset-2 col-sm-8", id: "job-#{job.id}"}
 	%h4
 		=link_to job.title, job_path(job)
 		-if job.status == 'revoked' 
@@ -7,12 +7,8 @@
 	%small
 		= "#{time_ago_in_words(job.created_at, )} ago"
 		
-		-if job.status == 'active'
-			-if pets_user.is_a?(CompanyPerson) || (pets_user.is_a?(AgencyPerson) && pets_user.is_job_developer?(pets_user.agency)) 
-				=link_to "revoke", '#', data: { :toggle => 'modal', :target => '#revokeModal' }
-				=render partial: 'revoke_modal', locals: { job: job }
-				
-				%button.btn.btn-primary.btn-xs.pull-right(data-target="#revokeModal" data-toggle="modal" type="button")revoke
-				=render partial: 'revoke_modal', locals: { job: job }
-				=link_to "edit", edit_job_path(job), class: "pull-right btn btn-primary btn-xs", 
-				       id: "jobs-edit-link"
+	-if job.status == 'active'
+		-if pets_user.is_a?(CompanyPerson) || (pets_user.is_a?(AgencyPerson) && pets_user.is_job_developer?(pets_user.agency))
+			%button.btn.btn-primary.btn-xs.pull-right{ type: "button", data: { action: 'revoke', job: { id: "#{job.id}", title: "#{job.title}", companyJobId: "#{job.company_job_id}" } } }revoke
+			=link_to "edit", edit_job_path(job), class: "pull-right btn btn-primary btn-xs", 
+			       id: "jobs-edit-link"

--- a/app/views/jobs/_job_info.html.haml
+++ b/app/views/jobs/_job_info.html.haml
@@ -7,6 +7,9 @@
       %td Job title:
       %td=@job.title
     %tr
+      %td Job status:
+      %td#job-status=@job.status
+    %tr
       %td Location:
       - if @job.address
         %td

--- a/app/views/jobs/_revoke_modal.html.haml
+++ b/app/views/jobs/_revoke_modal.html.haml
@@ -5,7 +5,6 @@
         %button.close{"data-dismiss" => "modal", :type => "button"}
           %span{"aria-hidden" => "true"} ×
         %h4.modal-title.text-center
-          =current_user.first_name if current_user
       .modal-body.text-center
         %p
           Are you sure you want to revoke the following job: 

--- a/app/views/jobs/_revoke_modal.html.haml
+++ b/app/views/jobs/_revoke_modal.html.haml
@@ -10,11 +10,10 @@
         %p
           Are you sure you want to revoke the following job: 
           %ul{class: "list-unstyled"}
-            %li job title: #{job.title}
-            %li job id: #{job.company_job_id}
+            %li#title
+            %li#company_job_id
 
       .modal-footer
         %button.btn.btn-default{"data-dismiss" => "modal",
-        :type => "button"} Close
-        =link_to "Revoke", revoke_job_path(job), method: :patch,
-        class: "btn btn-danger", id: "revoke-job-#{job.id}"
+        :type => "button"} Cancel
+        %a.btn.btn-danger#confirm_revoke{rel: "nofollow", data: { method: "patch"}} Revoke

--- a/app/views/jobs/_revoke_modal.html.haml
+++ b/app/views/jobs/_revoke_modal.html.haml
@@ -1,0 +1,20 @@
+#revokeModal.modal.fade{:role => "dialog", :tabindex => "-1"}
+  .modal-dialog{:role => "document"}
+    .modal-content
+      .modal-header
+        %button.close{"data-dismiss" => "modal", :type => "button"}
+          %span{"aria-hidden" => "true"} ×
+        %h4.modal-title.text-center
+          =current_user.first_name if current_user
+      .modal-body.text-center
+        %p
+          Are you sure you want to revoke the following job: 
+          %ul{class: "list-unstyled"}
+            %li job title: #{job.title}
+            %li job id: #{job.company_job_id}
+
+      .modal-footer
+        %button.btn.btn-default{"data-dismiss" => "modal",
+        :type => "button"} Close
+        =link_to "Revoke", revoke_job_path(job), method: :patch,
+        class: "btn btn-danger", id: "revoke-job-#{job.id}"

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -14,8 +14,7 @@
 		%strong{class: "text-center"}
 			%h3 There are no jobs available.
 - else
-	- @jobs.each do |job|
-		%div{class: "well well-lg col-sm-offset-2 col-sm-8", id: "sub-list-id"}
-			= render job
+	= render partial: "job", collection: @jobs 
+	
 %div{class: "col-sm-offset-4 col-sm-6"}
 	= will_paginate @jobs

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -14,6 +14,7 @@
 		%strong{class: "text-center"}
 			%h3 There are no jobs available.
 - else
+	= render partial: "revoke_modal"
 	= render partial: "job", collection: @jobs 
 	
 %div{class: "col-sm-offset-4 col-sm-6"}

--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -4,8 +4,8 @@
 	%div{class: "pull-right", id: "job-show-links-id"}
 		-if not pets_user.nil? and (pets_user.is_a?(CompanyPerson) or pets_user.is_job_developer?(current_agency))
 			-if @job.status == "active" 
-				=link_to "Revoke", '#', data: { :toggle => 'modal', :target => '#revokeModal' }
-				=render partial: 'revoke_modal', locals: { job: @job }
+				=render partial: 'revoke_modal'
+				=link_to "Revoke", '#', id: 'revoke_link', data: { "job-id" => "#{@job.id}", "job-title" => "#{@job.title}", "job-companyJobId" => "#{@job.company_job_id}"  }
 				|
 			=link_to "Edit Job", edit_job_path(@job)
 			|

--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -3,9 +3,10 @@
 %div{class: "col-sm-offset-1 col-sm-10"}
 	%div{class: "pull-right", id: "job-show-links-id"}
 		-if not pets_user.nil? and (pets_user.is_a?(CompanyPerson) or pets_user.is_job_developer?(current_agency))
-			=link_to "Delete", job_path(@job), method: :delete,
-				data: {confirm: "Are you sure you want to delete: #{@job.title}"}
-			|
+			-if @job.status == "active" 
+				=link_to "Revoke", '#', data: { :toggle => 'modal', :target => '#revokeModal' }
+				=render partial: 'revoke_modal', locals: { job: @job }
+				|
 			=link_to "Edit Job", edit_job_path(@job)
 			|
 		=link_to "Return To Jobs", jobs_path
@@ -16,8 +17,9 @@
 
 	= render partial: 'job_info'
 
-	- if not pets_user.nil? and policy(@job).apply?
-		=link_to "Click Here To Apply Online", '#', class: "col-sm-offset-4",
-					data: { :toggle => 'modal',
-									:target => '#applyJobModal'}
-		=render partial: 'apply_modal', :locals => {:job => @job}
+	-if @job.status == "active" 
+		-if not pets_user.nil? and policy(@job).apply?
+			=link_to "Click Here To Apply Online", '#', class: "col-sm-offset-4",
+						data: { :toggle => 'modal',
+										:target => '#applyJobModal'}
+			=render partial: 'apply_modal', :locals => {:job => @job}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
 
   resources :jobs do
     get 'applications', on: :member, as: :applications
+    patch 'revoke', on: :member, as: :revoke
   end
   # --------------------------------------------------------------------------
 

--- a/features/jobs.feature
+++ b/features/jobs.feature
@@ -62,15 +62,6 @@ Scenario: Creating, Updating, and Deleting Job successfully and unsuccessfully
 	Then I should see "cab-driver has been updated successfully."
 	And I should verify the change of title "cab-driver", shift "Day" and jobId "KRT123"
 
-	When I click the "Return To Jobs" link
-	And I click the first "delete" button
-	And I wait 1 second
-	Then I should see a popup with the following job information
-	And I wait 1 second
-	And I click the "modal-delete-id" link
-	And I wait 2 seconds
-	Then I should see "cab-driver has been deleted successfully."
-
   Then I go to the Company Person 'jane@widgets.com' Home page
   And I click the "software dev" link
   And I click the "Edit Job" link
@@ -96,7 +87,7 @@ Scenario: Creating, Updating, and Deleting Job successfully and unsuccessfully
 
 
 @selenium
-Scenario: Creating, Updating, and Deleting Job successfully and unsuccessfully
+Scenario: Creating and Updating Job successfully and unsuccessfully
   Given I am on the home page
 	And I login as "hr@metplus.org" with password "qwerty123"
 	When I click the "Post jobs" link

--- a/features/manage_job_status.feature
+++ b/features/manage_job_status.feature
@@ -39,43 +39,47 @@ Background: data is added to database
 		Given I am on the home page
 	  And I login as "ca@widgets.com" with password "qwerty123"
 	  And I visit the jobs page
-	  And I should not see "Revoked" span corresponds to "hr manager"
-	  But I should see "revoke" button corresponds to "hr manager"
-	  Then I click the "revoke" button belongs to "hr manager"
+	  And I should not see "Revoked" next to "hr manager"
+	  But I should see "revoke" button for "hr manager"
+	  Then I click the "revoke" button for "hr manager"
 	  And I wait 1 second
 	  And I should see a "revoke" confirmation
-	  Then I click the "Revoke" confirmation corresponds to "hr manager"
-	  And I should see "Revoked" span corresponds to "hr manager"
+	  Then I click the Revoke confirmation for "hr manager"
+	  And I should see "Revoked" next to "hr manager"
 
 	@selenium
 	Scenario: job developer revoke a job
 		Given I am on the home page
 		And I login as "john@metplus.org" with password "qwerty123"
 	  And I visit the jobs page
-	  And I should see "Revoked" span corresponds to "hr assistant"
+	  And I should see "Revoked" next to "hr assistant"
 	  Then I click the "hr assistant" link to job show page
 	  And I wait 1 second
+	  And I should see the job status is "revoked"
 	  And I should not see "Revoke" link on the page
  	  Then I return to jobs page   
  	  And I wait 1 second
- 	  And I should not see "Revoked" span corresponds to "hr associate"  
+ 	  And I should not see "Revoked" next to "hr associate"  
 	  Then I click the "hr associate" link to job show page 
+	  And I should see the job status is "active"
 	  And I should see "Revoke" link on the page
 	  Then I click the "Revoke" link
 	  And I wait 1 second
 		And I should see a "revoke" confirmation
-	  Then I click the "Revoke" confirmation corresponds to "hr associate"
-	  And I should see "Revoked" span corresponds to "hr associate"
+	  Then I click the Revoke confirmation for "hr associate"
+	  And I should see "Revoked" next to "hr associate"
 
 	Scenario: job seeker view job listed
 		Given I am on the home page
 		And I login as "john@seek.com" with password "qwerty123"
 		And I visit the jobs page
-	  And I should see "Revoked" span corresponds to "hr assistant"
+	  And I should see "Revoked" next to "hr assistant"
 	  Then I click the "hr assistant" link to job show page
+	  And I should see the job status is "revoked"
 	  And I should not see "Click Here To Apply Online"
 	  Then I return to jobs page
-	  And I should not see "Revoked" span corresponds to "hr manager"
+	  And I should not see "Revoked" next to "hr manager"
 	  Then I click the "hr manager" link to job show page
+	  And I should see the job status is "active"
 	  And I should see "Click Here To Apply Online"
 	

--- a/features/manage_job_status.feature
+++ b/features/manage_job_status.feature
@@ -38,31 +38,32 @@ Background: data is added to database
 	Scenario: company person revoke a job
 		Given I am on the home page
 	  And I login as "ca@widgets.com" with password "qwerty123"
-	  And I wait 2 seconds
 	  And I visit the jobs page
-	  And I wait 5 seconds
 	  And I should not see "Revoked" span corresponds to "hr manager"
 	  But I should see "revoke" button corresponds to "hr manager"
 	  Then I click the "revoke" button belongs to "hr manager"
-	  And I wait 5 seconds
-	  
-	  Then I click the "Revoke" confirmation corresponds to "hr manager"
 	  And I wait 1 second
+	  And I should see a "revoke" confirmation
+	  Then I click the "Revoke" confirmation corresponds to "hr manager"
 	  And I should see "Revoked" span corresponds to "hr manager"
 
+	@selenium
 	Scenario: job developer revoke a job
 		Given I am on the home page
 		And I login as "john@metplus.org" with password "qwerty123"
 	  And I visit the jobs page
 	  And I should see "Revoked" span corresponds to "hr assistant"
 	  Then I click the "hr assistant" link to job show page
+	  And I wait 1 second
 	  And I should not see "Revoke" link on the page
  	  Then I return to jobs page   
+ 	  And I wait 1 second
  	  And I should not see "Revoked" span corresponds to "hr associate"  
 	  Then I click the "hr associate" link to job show page 
 	  And I should see "Revoke" link on the page
-	  Then I click the first "Revoke" link
-	  And I should see a "revoke" confirmation
+	  Then I click the "Revoke" link
+	  And I wait 1 second
+		And I should see a "revoke" confirmation
 	  Then I click the "Revoke" confirmation corresponds to "hr associate"
 	  And I should see "Revoked" span corresponds to "hr associate"
 

--- a/features/manage_job_status.feature
+++ b/features/manage_job_status.feature
@@ -1,0 +1,80 @@
+Feature: Manage job status by UI
+
+	As a job developer / company person
+	So that there is no job application on expired job
+	I want to inform other job developer about a job status
+
+Background: data is added to database 
+
+	Given the default settings are present
+	
+	Given the following agency people exist:
+    | agency  | role      | first_name | last_name | email                | password  |
+    | MetPlus | JD        | John       | Smith     | john@metplus.org     | qwerty123 |
+    | MetPlus | CM        | Jane       | Jones     | jane@metplus.org     | qwerty123 |
+
+  Given the following companies exist:
+  	| agency  | name         | website     | phone        | email            | ein        | status |
+  	| MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
+  	| MetPlus | Feature Inc. | feature.com | 555-222-3333 | corp@feature.com | 12-3456788 | Active |
+
+  Given the following company people exist:
+  	| company      | role  | first_name | last_name | email            | password  | phone        |
+  	| Widgets Inc. | CA    | John       | Smith     | ca@widgets.com   | qwerty123 | 555-222-3334 |
+  	| Widgets Inc. | CC    | Jane       | Smith     | jane@widgets.com | qwerty123 | 555-222-3334 |
+  	| Feature Inc. | CA    | Charles    | Daniel    | ca@feature.com   | qwerty123 | 555-222-3334 |
+
+  Given the following jobseeker exist:
+  	| first_name | last_name | email         | phone        | password  | password_confirmation | year_of_birth | job_seeker_status  |
+  	| John       | Seeker    | john@seek.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+
+  Given the following jobs exist:
+    | title        | company_job_id | shift | fulltime | description | company      | creator        | status  |
+    | hr assistant | KRK01K         | Day		| true     | internship  | Widgets Inc. | ca@widgets.com | revoked |
+    | hr manager   | KRK02K         | Day   | true     | internship  | Widgets Inc. | ca@widgets.com | active  |
+    | hr associate | KRK03K         | Day   | true     | internship  | Widgets Inc. | ca@widgets.com | active  |
+  
+  @selenium
+	Scenario: company person revoke a job
+		Given I am on the home page
+	  And I login as "ca@widgets.com" with password "qwerty123"
+	  And I wait 2 seconds
+	  And I visit the jobs page
+	  And I wait 5 seconds
+	  And I should not see "Revoked" span corresponds to "hr manager"
+	  But I should see "revoke" button corresponds to "hr manager"
+	  Then I click the "revoke" button belongs to "hr manager"
+	  And I wait 5 seconds
+	  
+	  Then I click the "Revoke" confirmation corresponds to "hr manager"
+	  And I wait 1 second
+	  And I should see "Revoked" span corresponds to "hr manager"
+
+	Scenario: job developer revoke a job
+		Given I am on the home page
+		And I login as "john@metplus.org" with password "qwerty123"
+	  And I visit the jobs page
+	  And I should see "Revoked" span corresponds to "hr assistant"
+	  Then I click the "hr assistant" link to job show page
+	  And I should not see "Revoke" link on the page
+ 	  Then I return to jobs page   
+ 	  And I should not see "Revoked" span corresponds to "hr associate"  
+	  Then I click the "hr associate" link to job show page 
+	  And I should see "Revoke" link on the page
+	  Then I click the first "Revoke" link
+	  And I should see a "revoke" confirmation
+	  Then I click the "Revoke" confirmation corresponds to "hr associate"
+	  And I should see "Revoked" span corresponds to "hr associate"
+
+	Scenario: job seeker view job listed
+		Given I am on the home page
+		And I login as "john@seek.com" with password "qwerty123"
+		And I visit the jobs page
+	  And I should see "Revoked" span corresponds to "hr assistant"
+	  Then I click the "hr assistant" link to job show page
+	  And I should not see "Click Here To Apply Online"
+	  Then I return to jobs page
+	  And I should not see "Revoked" span corresponds to "hr manager"
+	  Then I click the "hr manager" link to job show page
+	  And I should see "Click Here To Apply Online"
+	

--- a/features/step_definitions/jobs_steps.rb
+++ b/features/step_definitions/jobs_steps.rb
@@ -16,3 +16,54 @@ end
 Given(/^the Widgets, Inc\. company name with address exist in the record$/) do
 	FactoryGirl.create(:company)
 end
+
+Then(/^I (?:visit|return to) the jobs page$/) do
+	@job = nil
+	visit jobs_path
+end
+
+# I should see "Revoked" span corresponds to "hr assistant"
+# I should see "revoke" button corresponds to "hr manager"
+Then(/^I should( not)? see "([^"]*)"( \w*) corresponds to "([^"]*)"$/) do |negate, tag_name, tag, job_title|
+	@job ||= Job.find_by(title: job_title)
+	if negate
+		expect(page).not_to have_css("#job-#{@job.id}#{tag}", text: tag_name)
+	else
+		expect(page).to have_css("#job-#{@job.id}#{tag}", text: tag_name)
+	end
+end
+
+Then(/^I should see a "([^"]*)" confirmation$/) do |action|
+	expect(page).to have_content("Are you sure you want 
+ 		         to #{action} the following job: 
+                 job title:  #{@job.title}
+                 job id: #{@job.company_job_id}")
+end 
+
+Then(/^I click the "revoke" button belongs to "hr manager"/) do
+	job = Job.find_by(title: "hr manager")
+	step %(I click the third "revoke" button)
+	byebug
+	find("#job-#{job.id} > button[data-target='#revokeModal']").click 
+end
+
+Then(/^I click the "([^"]*)" confirmation corresponds to "([^"]*)"$/) do |tag_name, job_title|
+	@job ||= Job.find_by(title: job_title)
+	step %{I click the "##{tag_name.downcase}-job-#{@job.id}" link}
+	# find("##{tag_name.downcase}-job-#{@job.id}").click
+end
+
+Then(/^I click the "([^"]*)" link to job show page$/) do |job_title|
+	@job ||= Job.find_by(title: job_title)
+	find("a[href='/jobs/#{@job.id}']").click
+end
+
+Then(/^I should( not)? see "Revoke" link on the page$/) do |negate|
+	if negate
+		expect(page).not_to have_css('a[data-target="#revokeModal"]', text: 'Revoke')
+	else
+		expect(page).to have_css('a[data-target="#revokeModal"]', text: 'Revoke')
+	end
+end
+
+

--- a/features/step_definitions/jobs_steps.rb
+++ b/features/step_definitions/jobs_steps.rb
@@ -22,15 +22,26 @@ Then(/^I (?:visit the |return to )jobs page$/) do
 	visit jobs_path
 end
 
-# I should see "Revoked" span corresponds to "hr assistant"
-# I should see "revoke" button corresponds to "hr manager"
-Then(/^I should( not)? see "([^"]*)"( \w*) corresponds to "([^"]*)"$/) do |negate, tag_name, tag, job_title|
+Then(/^I should( not)? see "Revoked" next to "([^"]*)"$/) do |negate, job_title|
 	@job ||= Job.find_by(title: job_title)
 	if negate
-		expect(page).not_to have_css("#job-#{@job.id}#{tag}", text: tag_name)
+		expect(page).not_to have_css("#job-#{@job.id} span", text: "Revoked")
 	else
-		expect(page).to have_css("#job-#{@job.id}#{tag}", text: tag_name)
+		expect(page).to have_css("#job-#{@job.id} span", text: "Revoked")
 	end
+end
+
+Then(/^I should( not)? see "revoke" button for "([^"]*)"$/) do |negate, job_title|
+	@job ||= Job.find_by(title: job_title)
+	if negate
+		expect(page).not_to have_css("#job-#{@job.id} button", text: "revoke")
+	else
+		expect(page).to have_css("#job-#{@job.id} button", text: "revoke")
+	end
+end
+
+Then(/^I should see the job status is "([^"]*)"$/) do |status|
+	within('#job-status') { expect(page).to have_content("#{status}") }
 end
 
 Then(/^I should see a "([^"]*)" confirmation$/) do |action|
@@ -40,14 +51,21 @@ Then(/^I should see a "([^"]*)" confirmation$/) do |action|
                  company job id: #{@job.company_job_id}")
 end 
 
-Then(/^I click the "revoke" button belongs to "hr manager"/) do
+Then(/^I should( not)? see "Revoke" link on the page$/) do |negate|
+	if negate
+		expect(page).not_to have_css('a#revoke_link', text: 'Revoke')
+	else
+		expect(page).to have_css('a#revoke_link', text: 'Revoke')
+	end
+end
+
+Then(/^I click the "revoke" button for "hr manager"/) do
 	job = Job.find_by(title: "hr manager")
 	find("#job-#{job.id} > button[data-action='revoke']").click 
 end
 
-Then(/^I click the "([^"]*)" confirmation corresponds to "([^"]*)"$/) do |tag_name, job_title|
+Then(/^I click the Revoke confirmation for "([^"]*)"$/) do |job_title|
 	@job ||= Job.find_by(title: job_title)
-	# step %{I click the "#confirm_revoke" link}
 	find("#confirm_revoke").click
 end
 
@@ -56,12 +74,6 @@ Then(/^I click the "([^"]*)" link to job show page$/) do |job_title|
 	find("a[href='/jobs/#{@job.id}']").click
 end
 
-Then(/^I should( not)? see "Revoke" link on the page$/) do |negate|
-	if negate
-		expect(page).not_to have_css('a#revoke_link', text: 'Revoke')
-	else
-		expect(page).to have_css('a#revoke_link', text: 'Revoke')
-	end
-end
+
 
 

--- a/features/step_definitions/jobs_steps.rb
+++ b/features/step_definitions/jobs_steps.rb
@@ -17,7 +17,7 @@ Given(/^the Widgets, Inc\. company name with address exist in the record$/) do
 	FactoryGirl.create(:company)
 end
 
-Then(/^I (?:visit|return to) the jobs page$/) do
+Then(/^I (?:visit the |return to )jobs page$/) do 
 	@job = nil
 	visit jobs_path
 end
@@ -37,20 +37,18 @@ Then(/^I should see a "([^"]*)" confirmation$/) do |action|
 	expect(page).to have_content("Are you sure you want 
  		         to #{action} the following job: 
                  job title:  #{@job.title}
-                 job id: #{@job.company_job_id}")
+                 company job id: #{@job.company_job_id}")
 end 
 
 Then(/^I click the "revoke" button belongs to "hr manager"/) do
 	job = Job.find_by(title: "hr manager")
-	step %(I click the third "revoke" button)
-	byebug
-	find("#job-#{job.id} > button[data-target='#revokeModal']").click 
+	find("#job-#{job.id} > button[data-action='revoke']").click 
 end
 
 Then(/^I click the "([^"]*)" confirmation corresponds to "([^"]*)"$/) do |tag_name, job_title|
 	@job ||= Job.find_by(title: job_title)
-	step %{I click the "##{tag_name.downcase}-job-#{@job.id}" link}
-	# find("##{tag_name.downcase}-job-#{@job.id}").click
+	# step %{I click the "#confirm_revoke" link}
+	find("#confirm_revoke").click
 end
 
 Then(/^I click the "([^"]*)" link to job show page$/) do |job_title|
@@ -60,9 +58,9 @@ end
 
 Then(/^I should( not)? see "Revoke" link on the page$/) do |negate|
 	if negate
-		expect(page).not_to have_css('a[data-target="#revokeModal"]', text: 'Revoke')
+		expect(page).not_to have_css('a#revoke_link', text: 'Revoke')
 	else
-		expect(page).to have_css('a[data-target="#revokeModal"]', text: 'Revoke')
+		expect(page).to have_css('a#revoke_link', text: 'Revoke')
 	end
 end
 

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -871,6 +871,11 @@ RSpec.describe JobsController, type: :controller do
         patch :revoke, id: @job.id
       end
 
+      it 'flash[:alert]' do
+        patch :revoke, id: @job.id
+        expect(flash[:alert]).to be_present.and eq "#{@job.title} is revoked successfully."
+      end
+
       it 'redirects to jobs_path' do
         patch :revoke, id: @job.id
         expect(response).to redirect_to(jobs_path)
@@ -884,7 +889,7 @@ RSpec.describe JobsController, type: :controller do
       end
 
       it 'flash[:alert]' do
-        expect(flash[:alert]).to be_present
+        expect(flash[:alert]).to be_present.and eq "Only active job can be revoked."
       end
 
       it 'redirects to jobs_path' do

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 include ServiceStubHelpers::Cruncher
 
+RSpec::Matchers.define :evt_obj do |*attributes|
+  match do |actual| 
+    if actual.is_a?(Struct)
+      attributes.each do |attribute|
+        return false unless actual.respond_to?(attribute)
+      end
+      return true
+    end
+    false
+  end
+end
+
 RSpec.describe JobsController, type: :controller do
 
   before(:example) do
@@ -406,7 +418,7 @@ RSpec.describe JobsController, type: :controller do
     let!(:skill)     { FactoryGirl.create(:skill, name: 'test skill') }
     let(:job3)       { FactoryGirl.create(:job, company: @company_person.company) }
     let!(:job_skill) { FactoryGirl.create(:job_skill, job: job3, skill: skill)}
-
+   
     it 'destroys job and associated job_skill' do
       expect { delete :destroy, :id => job_skill.job.id }.
         to change(Job, :count).by -1
@@ -724,6 +736,21 @@ RSpec.describe JobsController, type: :controller do
         expect(flash[:alert]).to eq "Unable to find the job the user is trying to apply to."
       end
     end
+
+    describe 'not active job' do
+      before :each do
+        revoked_job = FactoryGirl.create(:job, status: 'revoked')
+        allow(controller).to receive(:current_user).and_return(job_seeker)
+        get :apply, :job_id => revoked_job.id, :user_id => job_seeker.id
+      end
+      it "redirected to list of jobs" do
+        expect(response).to redirect_to(:action => 'index')
+      end
+      it 'check set flash' do
+        expect(flash[:alert]).to eq "Unable to apply. Job has either been filled or revoked."
+      end
+    end
+
     describe 'unknown job seeker' do
       before :each do
         allow(controller).to receive(:current_user).and_return(job_seeker)
@@ -824,5 +851,45 @@ RSpec.describe JobsController, type: :controller do
         expect(flash[:alert]).to eq "You are not authorized to perform this action."
       end
     end
+  end
+
+  describe 'PATCH #revoke' do
+
+    context 'active job' do
+      before :each do
+        @job = FactoryGirl.create(:job)
+      end
+
+      it 'changes job status from active to revoked' do
+        patch :revoke, id: @job.id
+        @job.reload
+        expect(@job.status).to eq('revoked')
+      end
+
+      it 'creates a job_revoked event' do
+        expect(Event).to receive(:create).with(:JOB_REVOKED, evt_obj(:job, :agency))
+        patch :revoke, id: @job.id
+      end
+
+      it 'redirects to jobs_path' do
+        patch :revoke, id: @job.id
+        expect(response).to redirect_to(jobs_path)
+      end
+    end
+
+    context 'revoked job' do
+      before :each do
+        @job = FactoryGirl.create(:job, status: 'revoked')
+        patch :revoke, id: @job.id
+      end
+
+      it 'flash[:alert]' do
+        expect(flash[:alert]).to be_present
+      end
+
+      it 'redirects to jobs_path' do
+        expect(response).to redirect_to(jobs_path)
+      end
+    end  
   end
 end

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -64,4 +64,13 @@ RSpec.describe NotifyEmailJob, type: :job do
       to change(Delayed::Job, :count).by(+1)
   end
 
+  it 'job revoked' do
+    expect{ NotifyEmailJob.set(wait: Event.delay_seconds.seconds).
+                 perform_later('job_developer@gmail.com',
+                 Event::EVT_TYPE[:JOB_REVOKED],
+                 {job: {title: 'test job'},
+                  agency: {name: 'MetPlus'}}) }.
+      to change(Delayed::Job, :count).by(+1)
+  end
+
 end

--- a/spec/mailers/agency_mailer_spec.rb
+++ b/spec/mailers/agency_mailer_spec.rb
@@ -148,4 +148,29 @@ RSpec.describe AgencyMailer, type: :mailer do
     end
   end
 
+  describe 'Job revoked' do
+
+    let(:job)           { FactoryGirl.create(:job) }
+    let(:job_developer) { FactoryGirl.create(:job_developer)}
+
+    let(:mail) do
+      allow(Pusher).to receive(:trigger)
+      stub_cruncher_authenticate
+      stub_cruncher_job_create
+      AgencyMailer.job_revoked(job_developer.email, job)
+    end
+
+    it "renders the headers" do
+      expect(mail.subject).to eq 'Job revoked'
+      expect(mail.to).to eq(["#{job_developer.email}"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+    it "renders the body" do
+      expect(mail).to have_body_text(/A job \(\n.*#{Regexp.quote(job.title)}.*\n\) has been revoked for company: #{Regexp.quote(job.company.name)}\./)
+    end
+    it "includes link to show job" do
+      expect(mail).to have_body_text(/#{job_url(id: 1)}/)
+    end
+  end
+
 end

--- a/spec/mailers/previews/agency_mailer_preview.rb
+++ b/spec/mailers/previews/agency_mailer_preview.rb
@@ -47,4 +47,15 @@ class AgencyMailerPreview < ActionMailer::Preview
     AgencyMailer.job_posted(job_developer.email, job)
   end
 
+  def job_revoked
+    job = Job.create(title: 'Software Engineer',
+                  company: Company.first,
+                  company_job_id: 'XYZ',
+                  shift: Job::SHIFT_OPTIONS[0],
+                  description: 'description of test job')
+    job_developer = User.find_by_email('chet@metplus.org').actable
+
+    AgencyMailer.job_revoked(job_developer.email, job)
+  end
+
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -180,6 +180,26 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe 'job_revoked event' do
+
+    it 'triggers mass Pusher message' do
+      Event.create(:JOB_REVOKED, evt_obj_jobpost)
+
+      expect(Pusher).to have_received(:trigger).
+                    with('pusher_control',
+                         'job_revoked',
+                         {job_id: job.id,
+                          job_title: job.title,
+                          company_name: company.name,
+                          notify_list: [job_developer.user.id]})
+    end
+
+    it 'sends mass event notification email' do
+      expect { Event.create(:JOB_REVOKED, evt_obj_jobpost) }.
+                    to change(all_emails, :count).by(+1)
+    end
+  end
+
   describe 'jd_self_assigned_js event' do
 
     it 'triggers Pusher message to job seeker' do


### PR DESCRIPTION
Implemented tasks
- revoke job by updating job.status from 'active' to 'revoked'
- only 'active' job can be 'revoked'
- 'revoked' job can not be applied. But still in the Jobs list.
- notification and email events to job developers after a single job is revoked
- confirmation on revoke action 
- change of view & test accordingly

not implemented
- authorization for revoke
- should the email & notification events happen for a collection of job instead?
