### PR TITLE
Closes AgileVentures/MetPlus_tracker#372

### DIFF
--- a/app/assets/javascripts/job_applications.js
+++ b/app/assets/javascripts/job_applications.js
@@ -1,0 +1,15 @@
+$(function() {
+  $('.pagination-div, #application-show-links').on('click', '.accept_link', function() {
+    var id = $(this).attr('data-application-id');
+    var title = $(this).attr('data-job-title');
+    var companyJobId = $(this).attr('data-job-companyJobId');
+    var jobSeeker = $(this).attr('data-jobSeeker');
+   
+    $('#acceptModal').find('.modal-title').html(title);
+    $('#acceptModal').find('#job_seeker').html("applicant's name: " + jobSeeker);
+    $('#acceptModal').find('#title').html('job title: ' + title);
+    $('#acceptModal').find('#company_job_id').html('company job id: ' + companyJobId);
+    $('#acceptModal').find('#confirm_accept').attr('href','/job_applications/' + id + '/accept');
+    $('#acceptModal').modal();
+  });
+});

--- a/app/assets/javascripts/pusher.js.erb
+++ b/app/assets/javascripts/pusher.js.erb
@@ -47,6 +47,15 @@ var PusherControl = {
       }
     });
 
+    channel.bind('job_application_accepted', function(data) {
+      if (parseInt(Cookies('user_id')) === data.jd_user_id) {
+        Notification.info_notification("Job Application: " +
+          "<a href='/job_applications/" + data.id + 
+          "' target='_blank'>" + data.job_title + " by " +
+          data.js_name + "</a>" + " is accepted.");
+      }
+    });
+
     channel.bind('jobseeker_assigned_jd', function(data) {
       // Process event if I am logged in and I am the job developer
       if (parseInt(Cookies('user_id')) === data.jd_user_id) {

--- a/app/assets/stylesheets/jobs.css.scss
+++ b/app/assets/stylesheets/jobs.css.scss
@@ -25,7 +25,7 @@ $state-danger-text: #a94442;
 
 }
 
-.pull-right#job-show-links-id{
+.pull-right#job-show-links-id, .pull-right#application-show-links{
 		margin-top: 80px;
 		a{
 			text-decoration: underline;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
   end
 
   protect_from_forgery with: :exception
+  def redirect_back_or_default(default = root_path)
+    redirect_to (request.referer.present? ? :back : default)
+  end
+  
   helper_method :pets_user, :current_agency, :determine_if_admin
 
   include Pundit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,9 @@ class ApplicationController < ActionController::Base
     stored_location_for(resource) || request.referer || root_path
   end
 
+  def redirect_back_or_default(default = root_path)
+    redirect_to (request.referer.present? ? :back : default)
+  end
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,10 +30,6 @@ class ApplicationController < ActionController::Base
     stored_location_for(resource) || request.referer || root_path
   end
 
-  def redirect_back_or_default(default = root_path)
-    redirect_to (request.referer.present? ? :back : default)
-  end
-
   protected
 
     def action_description

--- a/app/controllers/concerns/job_applications_viewer.rb
+++ b/app/controllers/concerns/job_applications_viewer.rb
@@ -20,14 +20,14 @@ module JobApplicationsViewer
     when 'job-applied'
       return JobApplication.paginate(page: params[:applications_page],
                :per_page => per_page).where(job: job_id).
-               includes(:job_seeker)
+               includes(:job_seeker).order(:status)
     end
   end
 
   FIELDS_IN_APPLICATION_TYPE = {
       'my-applied': [:title, :description, :company, :updated_at, :status],
       'js-applied': [:title, :description, :company, :updated_at, :status],
-      'job-applied': [:name, :js_status, :updated_at, :status]
+      'job-applied': [:name, :js_status, :updated_at, :action]
   }
 
   def application_fields application_type

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -25,9 +25,5 @@ class JobApplicationsController < ApplicationController
 			redirect_back_or_default
 		end
 	end
-
-	def redirect_back_or_default(default = root_path)
-    redirect_to (request.referer.present? ? :back : default)
-  end
   
 end

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -1,0 +1,28 @@
+class JobApplicationsController < ApplicationController
+	include JobApplicationsViewer
+
+	before_action :find_application
+
+	def accept
+		unless @job_application.active? 
+			flash[:alert] = "Invalid action on inactive job application."
+		else
+			begin
+				@job_application.accept
+				Event.create(:APP_ACCEPTED, @job_application)
+				flash[:info] = "Job application accepted."
+			rescue Exception => e
+				flash[:alert] = "Unable to accept at this moment, please try again."
+			end
+		end
+		redirect_to applications_job_url(@job_application.job)
+	end
+
+	def show
+	end
+
+	def find_application
+		@job_application = JobApplication.find(params[:id])
+		flash[:alert] = "Job Application Entry not found." unless @job_application
+	end
+end

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -7,13 +7,9 @@ class JobApplicationsController < ApplicationController
 		unless @job_application.active? 
 			flash[:alert] = "Invalid action on inactive job application."
 		else
-			begin
-				@job_application.accept
-				Event.create(:APP_ACCEPTED, @job_application)
-				flash[:info] = "Job application accepted."
-			rescue Exception => e
-				flash[:alert] = "Unable to accept at this moment, please try again."
-			end
+			@job_application.accept
+			Event.create(:APP_ACCEPTED, @job_application) if @job_application.job_seeker.job_developer
+			flash[:info] = "Job application accepted."
 		end
 		redirect_to applications_job_url(@job_application.job)
 	end
@@ -22,7 +18,11 @@ class JobApplicationsController < ApplicationController
 	end
 
 	def find_application
-		@job_application = JobApplication.find(params[:id])
-		flash[:alert] = "Job Application Entry not found." unless @job_application
+		begin
+			@job_application = JobApplication.find(params[:id])
+		rescue
+			flash[:alert] = "Job Application Entry not found."
+			redirect_back_or_default
+		end
 	end
 end

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -25,4 +25,9 @@ class JobApplicationsController < ApplicationController
 			redirect_back_or_default
 		end
 	end
+
+	def redirect_back_or_default(default = root_path)
+    redirect_to (request.referer.present? ? :back : default)
+  end
+  
 end

--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -12,6 +12,9 @@ class NotifyEmailJob < ActiveJob::Base
     when Event::EVT_TYPE[:JS_APPLY]
       AgencyMailer.job_seeker_applied(email_addresses, evt_obj).deliver_later
 
+    when Event::EVT_TYPE[:APP_ACCEPTED]
+      AgencyMailer.job_application_accepted(email_addresses, evt_obj).deliver_later
+
     when Event::EVT_TYPE[:JD_ASSIGNED_JS]
       AgencyMailer.job_seeker_assigned_jd(email_addresses, evt_obj).deliver_later
 

--- a/app/mailers/agency_mailer.rb
+++ b/app/mailers/agency_mailer.rb
@@ -12,6 +12,10 @@ class AgencyMailer < ApplicationMailer
     send_notification_mail(email_list, job_application, 'Job Application')
   end
 
+  def job_application_accepted(email_list, job_application)
+    send_notification_mail(email_list, job_application, 'Job Application Accepted')
+  end
+
   def job_seeker_assigned_jd(email_list, job_seeker)
     send_notification_mail(email_list, job_seeker, 'Job Seeker Assigned JD')
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,7 @@ class Event
               COMP_APPROVED: 'company_registration_approved',
               COMP_DENIED:   'company_registration_denied',
               JS_APPLY:      'jobseeker_applied',
+              APP_ACCEPTED:  'job_application_accepted', 
               JOB_POSTED:    'job_posted',
               JOB_REVOKED:   'job_revoked', 
               JD_ASSIGNED_JS:    'jobseeker_assigned_jd',
@@ -40,6 +41,8 @@ class Event
       evt_comp_denied(evt_obj)
     when :JS_APPLY
       evt_js_apply(evt_obj)
+    when :APP_ACCEPTED
+      evt_app_accepted(evt_obj)
     when :JOB_POSTED
       evt_job_posted(evt_obj)
     when :JOB_REVOKED
@@ -137,6 +140,24 @@ class Event
     end
 
     Task.new_review_job_application_task(evt_obj.job, evt_obj.job.company)
+  end
+
+  def self.evt_app_accepted(evt_obj)
+    # evt_obj = job application
+    # Business rules:
+    #    Notify job seeker's job developer (email and popup)
+
+    Pusher.trigger('pusher_control',
+                   EVT_TYPE[:APP_ACCEPTED],
+                   {id: evt_obj.id,
+                    jd_user_id: evt_obj.job_seeker.job_developer.user.id,
+                    job_title:   evt_obj.job.title,
+                    js_name: evt_obj.job_seeker.full_name(last_name_first: false)
+                    })
+    NotifyEmailJob.set(wait: delay_seconds.seconds).
+                   perform_later(evt_obj.job_seeker.job_developer.user.email,
+                   EVT_TYPE[:APP_ACCEPTED],
+                   evt_obj)
   end
 
   def self.evt_jd_assigned_js(evt_obj)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -46,6 +46,10 @@ class Job < ActiveRecord::Base
     save!
   end
 
+  def filled
+    update_attribute(:status, STATUS[:FILLED])
+  end
+
   def last_application_by_job_seeker(job_seeker)
     job_applications.where(job_seeker: job_seeker).order(:created_at).last
   end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -6,4 +6,18 @@ class JobApplication < ActiveRecord::Base
   def status_name
     status.to_s.camelcase
   end
+
+  def active?
+    super && job.status == 'active'
+  end
+
+  def accept
+    accepted!
+		reject_applications = job.job_applications.where.not(id: self.id)
+		reject_applications.each do |application| 
+			application.not_accepted!
+		end
+    job.filled
+  end
+
 end

--- a/app/views/agency_mailer/agency_notification.html.haml
+++ b/app/views/agency_mailer/agency_notification.html.haml
@@ -19,6 +19,11 @@
     The job seeker who applied is:
     = link_to @obj.job_seeker.full_name, job_seeker_url(id: @obj.job_seeker.id)
 
+  - elsif @obj_type == 'Job Application Accepted'
+    A job application is accepted:
+    = link_to "#{@obj.job.title} by #{@obj.job_seeker.full_name(last_name_first: false)}",
+      application_url(id: @obj.id)
+
   - elsif @obj_type == 'Job Seeker Assigned JD'
     A job seeker has been assigned to you as Job Developer:
     = link_to @obj.full_name(last_name_first: false),

--- a/app/views/job_applications/_accept_modal.html.haml
+++ b/app/views/job_applications/_accept_modal.html.haml
@@ -1,0 +1,19 @@
+#acceptModal.modal.fade{:role => "dialog", :tabindex => "-1"}
+  .modal-dialog{:role => "document"}
+    .modal-content
+      .modal-header
+        %button.close{"data-dismiss" => "modal", :type => "button"}
+          %span{"aria-hidden" => "true"} ×
+        %h4.modal-title.text-center
+      .modal-body.text-center
+        %p
+          Are you sure you want to accept the following application: 
+          %ul{class: "list-unstyled"}
+            %li#job_seeker
+            %li#title
+            %li#company_job_id
+
+      .modal-footer
+        %button.btn.btn-default{"data-dismiss" => "modal",
+        :type => "button"} Cancel
+        %a.btn.btn-danger#confirm_accept{rel: "nofollow", data: { method: "patch"}} Accept

--- a/app/views/job_applications/show.html.haml
+++ b/app/views/job_applications/show.html.haml
@@ -1,7 +1,12 @@
 .col-sm-offset-1.col-sm-10
-	.pull-right#job-show-links-id
+	.pull-right#application-show-links
 		- if @job_application.status == 'active'
-			=link_to "Accept", accept_application_path(@job_application), method: :patch, id: "accept-#{@job_application.id}-button"
+			= render partial: 'accept_modal'
+			= link_to "Accept", '#', class: "accept_link", 
+			  data: { "application-id" => "#{@job_application.id}", 
+			 				  "job-title" => "#{@job_application.job.title}", 
+			 				  "jobSeeker" => "#{@job_application.job_seeker.full_name(last_name_first: false)}",
+			 				  "job-companyJobId" => "#{@job_application.job.company_job_id}" }
 			|
 		=link_to "Return To Applications", applications_job_path(@job_application.job_id)
 

--- a/app/views/job_applications/show.html.haml
+++ b/app/views/job_applications/show.html.haml
@@ -1,0 +1,26 @@
+.col-sm-offset-1.col-sm-10
+	.pull-right#job-show-links-id
+		- if @job_application.status == 'active'
+			=link_to "Accept", accept_application_path(@job_application), method: :patch, id: "accept-#{@job_application.id}-button"
+			|
+		=link_to "Return To Applications", applications_job_path(@job_application.job_id)
+
+	.clearfix
+	
+	.panel.panel-default#show-panel-id
+		.panel-heading#panel-heading-show-id 
+			%h4
+				= "#{@job_application.job.title}"
+				- if @job_application.status != 'active'
+					%span{class: 'label label-info'}="#{@job_application.status}"
+
+		= render partial: 'job_seekers/info', locals: {job_seeker: @job_application.job_seeker}
+
+		
+
+
+
+
+
+
+

--- a/app/views/job_seekers/_info.html.haml
+++ b/app/views/job_seekers/_info.html.haml
@@ -35,7 +35,7 @@
         %strong Case Manager
       %td
         #assigned_case_manager
-          = render :partial => 'assigned_agency_person',
+          = render :partial => 'job_seekers/assigned_agency_person',
                         :locals => {person: pets_user,
                                     job_seeker: job_seeker,
                                     agency_role: 'CM'}
@@ -44,7 +44,7 @@
         %strong Job Developer
       %td
         #assigned_job_developer
-          = render :partial => 'assigned_agency_person',
+          = render :partial => 'job_seekers/assigned_agency_person',
                         :locals => {person: pets_user,
                                     job_seeker: job_seeker,
                                     agency_role: 'JD'}

--- a/app/views/jobs/_applied_job_list.html.haml
+++ b/app/views/jobs/_applied_job_list.html.haml
@@ -20,7 +20,7 @@
               %th.strong Status
     %tbody
       - job_applications.each do |job_application|
-        %tr
+        %tr{id: "applications-#{job_application.id}"}
           - application_fields(application_type).each do |field|
             - case field
               - when :title

--- a/app/views/jobs/_job.html.haml
+++ b/app/views/jobs/_job.html.haml
@@ -1,8 +1,8 @@
 %div{class: "well well-lg col-sm-offset-2 col-sm-8", id: "job-#{job.id}"}
 	%h4
 		=link_to job.title, job_path(job)
-		-if job.status == 'revoked' 
-			%span{class: 'label label-info'} Revoked
+		-if job.status != 'active' 
+			%span{class: 'label label-info'}= "#{job.status.capitalize}"
 	%h5= job.company.name
 	%small
 		= "#{time_ago_in_words(job.created_at, )} ago"

--- a/app/views/jobs/_job_applications.html.haml
+++ b/app/views/jobs/_job_applications.html.haml
@@ -1,5 +1,4 @@
 -# partial for job applications for a specific job
-
 - if @applications.empty?
   %span(style='padding-left: 10px;') None
 - else
@@ -14,8 +13,8 @@
               %th.strong Job Seeker Status
             - when :updated_at
               %th.strong Applied
-            - when :status
-              %th.strong Application Status
+            - when :action
+              %th.strong Action
     %tbody
       - @applications.each do |job_application|
         %tr
@@ -24,16 +23,19 @@
               - when :name
                 %td
                   = link_to job_application.job_seeker.full_name,
-                            job_seeker_path(job_application.job_seeker)
+                            application_path(job_application)
               - when :js_status
                 %td
                   = job_application.job_seeker.job_seeker_status.short_description
               - when :updated_at
                 %td
                   = "#{time_ago_in_words(job_application.updated_at, )} ago"
-              - when :status
+              - when :action
                 %td
-                  = job_application.status_name
+                  - if job_application.active?
+                    = link_to "accept", accept_application_path(job_application), method: :patch, class: "btn btn-default", id: "#{job_application.id}-#{job_application.status}"
+                  - else
+                    = link_to "#{job_application.status}", accept_application_path(job_application), method: :patch, class: "btn btn-default disabled", id: "#{job_application.id}-#{job_application.status}"
 
   = will_paginate @applications, param_name: 'applications_page',
                                params: {controller: 'jobs',

--- a/app/views/jobs/_job_applications.html.haml
+++ b/app/views/jobs/_job_applications.html.haml
@@ -17,7 +17,7 @@
               %th.strong Action
     %tbody
       - @applications.each do |job_application|
-        %tr
+        %tr{id: "applications-#{job_application.id}"}
           - application_fields(@application_type).each do |field|
             - case field
               - when :name
@@ -33,9 +33,13 @@
               - when :action
                 %td
                   - if job_application.active?
-                    = link_to "accept", accept_application_path(job_application), method: :patch, class: "btn btn-default", id: "#{job_application.id}-#{job_application.status}"
+                    = link_to "accept", '#', class: "accept_link btn btn-default", 
+                      data: { "application-id" => "#{job_application.id}", 
+                              "job-title" => "#{job_application.job.title}", 
+                              "jobSeeker" => "#{job_application.job_seeker.full_name(last_name_first: false)}",
+                              "job-companyJobId" => "#{job_application.job.company_job_id}" }
                   - else
-                    = link_to "#{job_application.status}", accept_application_path(job_application), method: :patch, class: "btn btn-default disabled", id: "#{job_application.id}-#{job_application.status}"
+                    = link_to "#{job_application.status}", '#', class: "btn btn-default disabled"
 
   = will_paginate @applications, param_name: 'applications_page',
                                params: {controller: 'jobs',

--- a/app/views/jobs/_job_info.html.haml
+++ b/app/views/jobs/_job_info.html.haml
@@ -5,7 +5,7 @@
   %tbody
     %tr
       %td Job title:
-      %td=@job.title
+      %td#job-title=@job.title
     %tr
       %td Job status:
       %td#job-status=@job.status

--- a/app/views/jobs/applications.html.haml
+++ b/app/views/jobs/applications.html.haml
@@ -9,5 +9,7 @@
 .col-sm-12
   %h3
     Applications for this Job
+    
+  = render partial: 'job_applications/accept_modal'
   .pagination-div{id: "applications-#{@application_type}",
                   data: {url: applications_list_path(@job, @application_type)}}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,13 @@ Rails.application.routes.draw do
   end
   # --------------------------------------------------------------------------
 
+  # --------------------------- Job Applications -----------------------------
+  patch 'job_applications/:id/accept'    => 'job_applications#accept', 
+                                             as: :accept_application
+  get 'job_applications/:id'             => 'job_applications#show',
+                                             as: :application
+  # --------------------------------------------------------------------------
+  
   # ---------------------------- Job Seekers ---------------------------------
   resources :job_seekers do
      get 'home', on: :member, as: :home

--- a/features/accept_job_application.feature
+++ b/features/accept_job_application.feature
@@ -1,0 +1,98 @@
+Feature: Accept a job application
+
+	As a company person
+	I want to accept a job application
+
+Background: data is added to database 
+
+	Given the default settings are present
+
+	Given the following agency people exist:
+    | agency  | role      | first_name | last_name | email                | password  |
+    | MetPlus | JD        | Dave       | Smith     | dave@metplus.org     | qwerty123 |
+
+  Given the following companies exist:
+  	| agency  | name         | website     | phone        | email            | ein        | status |
+  	| MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
+
+  Given the following company people exist:
+  	| company      | role  | first_name | last_name | email            | password  | phone        |
+  	| Widgets Inc. | CC    | Cicil      | Smith     | cicil@widgets.com | qwerty123 | 555-222-3334 |
+  	| Widgets Inc. | CA    | Cane       | Daniel    | cane@widgets.com | qwerty123 | 555-222-3334 |
+
+  Given the following jobseeker exist:
+  	| first_name | last_name | email         | phone        | password  | password_confirmation | year_of_birth | job_seeker_status  |
+  	| John       | Seeker    | john@seek.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+  	| Jane       | Seeker    | jane@seek.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+  	| June       | Seeker    | june@seek.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+
+  Given the following agency relations exist:
+		| job_seeker    | agency_person    | role |
+		| john@seek.com | dave@metplus.org | JD   |
+		| june@seek.com | dave@metplus.org | JD   |
+
+  Given the following jobs exist:
+    | title        | company_job_id | shift | fulltime | description | company      | creator        | skills  |
+    | hr manager   | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com | leadership  |
+    
+	Given the following job applications exist:
+		| job title 	 | job seeker 	 | status 			|
+		| hr manager	 | john@seek.com | active 			|
+		| hr manager	 | jane@seek.com | active 			|
+		| hr manager	 | june@seek.com | active 			|
+
+	@javascript
+	Scenario: company contact accept a job application
+		Given I am on the home page
+	  And I login as "cicil@widgets.com" with password "qwerty123"
+	  And I wait 1 second
+	  Then I click "hr manager" link to job applications index page 
+	  And I should see "3" active applications for the job
+	  Then I accept "jane@seek.com" application
+	  And I should see an "accept" confirmation
+	  Then I click the "Accept" confirmation
+	  And I should see "jane@seek.com" application is listed first
+	  And I should see "jane@seek.com" application changes to accepted 
+	  And other applications change to not accepted
+	  And I should see "hr manager" job changes to status filled
+
+	@javascript
+	Scenario: company admin accept a job application
+		Given I am on the home page
+	  And I login as "cane@widgets.com" with password "qwerty123"
+	  And I wait 1 second
+	  Then I click "hr manager" link to job applications index page 
+	  And I should see "3" active applications for the job
+	  Then I click "june@seek.com" link to "June's" job application show page
+	  And I should see an "Accept" link
+	  Then I click the "Accept" link
+	  And I should see an "accept" confirmation
+	  Then I click the "Accept" confirmation
+	  And I am returned to "hr manager" job application index page
+	  And I should see "june@seek.com" application is listed first
+	  And I should see "june@seek.com" application changes to accepted 
+	  And other applications change to not accepted
+	  And I should see "hr manager" job changes to status filled
+	  Then I click "june@seek.com" link to "June's" job application show page
+	  And I should not see "Accept" link
+
+	@selenium
+	Scenario: job developer accept notification when job application accepted
+	  When I am in Job Developer's browser
+	  Given I am on the home page
+	  And I login as "dave@metplus.org" with password "qwerty123"
+
+	  When I am in Company Admin's browser
+	  Given I am on the home page
+	  And I login as "cane@widgets.com" with password "qwerty123"
+	  Then I click "hr manager" link to job applications index page 
+	  And I accept "john@seek.com" application
+	  And I click the "Accept" confirmation
+
+	  Then I am in Job Developer's browser
+	  And I should see "Job Application: hr manager by John Seeker is accepted"
+	  And "dave@metplus.org" should receive an email with subject "Job application accepted"
+	  Then "dave@metplus.org" opens the email
+	  And I should see "A job application is accepted:" in the email body
+	  
+

--- a/features/accept_job_application.feature
+++ b/features/accept_job_application.feature
@@ -12,8 +12,8 @@ Background: data is added to database
     | MetPlus | JD        | Dave       | Smith     | dave@metplus.org     | qwerty123 |
 
   Given the following companies exist:
-  	| agency  | name         | website     | phone        | email            | ein        | status |
-  	| MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
+  	| agency  | name         | website     | phone        | email            | job_email        | ein        | status |
+  	| MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | corp@widgets.com | 12-3456789 | Active |
 
   Given the following company people exist:
   	| company      | role  | first_name | last_name | email            | password  | phone        |
@@ -32,8 +32,8 @@ Background: data is added to database
 		| june@seek.com | dave@metplus.org | JD   |
 
   Given the following jobs exist:
-    | title        | company_job_id | shift | fulltime | description | company      | creator        | skills  |
-    | hr manager   | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com | leadership  |
+    | title        | company_job_id | shift | fulltime | description | company      | creator          |
+    | hr manager   | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com | 
     
 	Given the following job applications exist:
 		| job title 	 | job seeker 	 | status 			|

--- a/features/company_person.feature
+++ b/features/company_person.feature
@@ -43,30 +43,6 @@ Feature: Company Person
       | Widgets Inc. | CC    | Jane       | Smith     | jane@widgets.com | qwerty123 | 555-222-3334 |
       | Feature Inc. | CA    | Charles    | Daniel    | ca@feature.com   | qwerty123 | 555-222-3334 |
 
-    Given the following jobs exist:
-      | title               | company_job_id  | shift  | fulltime | description                 | company      | creator        |
-      | software developer  | KRK01K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK02K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK03K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK04K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK05K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK06K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK07K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK08K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK09K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | software developer  | KRK10K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK11K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Doctor              | AAEE1K          | Evening| true     | internship position with pay| Feature Inc. | ca@feature.com |
-      | Cook                | KRK12K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK13K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK14K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK15K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK16K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK17K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK18K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK19K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-      | Cook                | KRK20K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
-
   Scenario: company admin edits company info
     Given I am on the home page
     And I login as "ca@widgets.com" with password "qwerty123"
@@ -186,16 +162,6 @@ Feature: Company Person
     Then I click "Update Company person" button
     And I should be on the Company person 'jane@widgets.com' show page
     And I should see "12 Main Street Detroit, Michigan 02034"
-
-  @javascript
-  Scenario: verify job listing in home page
-    Given I am on the home page
-    And I login as "ca@widgets.com" with password "qwerty123"
-    And I should be on the Company Person 'ca@widgets.com' Home page
-    And I wait for 5 seconds
-    And I should see "Cook"
-    And I should not see "Doctor"
-    And I should not see "software developer"
 
   @javascript
   Scenario: verify people listing in home page

--- a/features/company_person_jobs_view.feature
+++ b/features/company_person_jobs_view.feature
@@ -1,0 +1,77 @@
+Feature: Company Person Jobs View
+
+  As a company person
+  I want to view all available job listings in my company
+
+  Background:
+    Given the following agency roles exist:
+      | role  |
+      | AA    |
+      | CM    |
+      | JD    |
+
+    Given the following agencies exist:
+      | name    | website     | phone        | email                  | fax          |
+      | MetPlus | metplus.org | 555-111-2222 | pets_admin@metplus.org | 617-555-1212 |
+
+    Given the following agency people exist:
+      | agency  | role  | first_name | last_name | email            | password  |
+      | MetPlus | AA    | John       | Smith     | aa@metplus.org   | qwerty123 |
+      | MetPlus | CM    | Jane       | Jones     | jane@metplus.org | qwerty123 |
+
+    Given the following company roles exist:
+      | role  |
+      | CA    |
+      | CC    |
+
+    Given the following companies exist:
+      | agency  | name         | website     | phone        | email            | ein        | status |
+      | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
+      | MetPlus | Feature Inc. | feature.com | 555-222-3333 | corp@feature.com | 12-3456788 | Active |
+
+    Given the following company addresses exist:
+      | company       | street           | city    | zipcode | state      |
+      | Widgets Inc.  | 12 Main Street   | Detroit | 02034   | Michigan   |
+      | Widgets Inc.  | 14 Main Street   | Detroit | 02034   | Michigan   |
+      | Feature Inc.  | 100 River Valley | Utah    | 12334   | New Jersey |
+      | Feature Inc.  | 111 River Valley | Utah    | 12334   | New Jersey |
+
+    Given the following company people exist:
+      | company      | role  | first_name | last_name | email            | password  | phone        |
+      | Widgets Inc. | CA    | John       | Smith     | ca@widgets.com   | qwerty123 | 555-222-3334 |
+      | Widgets Inc. | CC    | Jane       | Smith     | jane@widgets.com | qwerty123 | 555-222-3334 |
+      | Feature Inc. | CA    | Charles    | Daniel    | ca@feature.com   | qwerty123 | 555-222-3334 |
+
+    Given the following jobs exist:
+      | title               | company_job_id  | shift  | fulltime | description                 | company      | creator        |
+      | software developer  | KRK01K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK02K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK03K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK04K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK05K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK06K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK07K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK08K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK09K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | software developer  | KRK10K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK11K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Doctor              | AAEE1K          | Evening| true     | internship position with pay| Feature Inc. | ca@feature.com |
+      | Cook                | KRK12K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK13K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK14K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK15K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK16K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK17K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK18K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK19K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+      | Cook                | KRK20K          | Evening| true     | internship position with pay| Widgets Inc. | ca@widgets.com |
+
+  @javascript
+  Scenario: verify job listing in home page
+    Given I am on the home page
+    And I login as "ca@widgets.com" with password "qwerty123"
+    And I should be on the Company Person 'ca@widgets.com' Home page
+    And I wait for 5 seconds
+    And I should see "Cook"
+    And I should not see "Doctor"
+    And I should not see "software developer"

--- a/features/company_person_jobs_view.feature
+++ b/features/company_person_jobs_view.feature
@@ -25,9 +25,9 @@ Feature: Company Person Jobs View
       | CC    |
 
     Given the following companies exist:
-      | agency  | name         | website     | phone        | email            | ein        | status |
-      | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
-      | MetPlus | Feature Inc. | feature.com | 555-222-3333 | corp@feature.com | 12-3456788 | Active |
+      | agency  | name         | website     | phone        | email            | job_email        | ein        | status |
+      | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | corp@widgets.com | 12-3456789 | Active |
+      | MetPlus | Feature Inc. | feature.com | 555-222-3333 | corp@feature.com | corp@feature.com | 12-3456788 | Active |
 
     Given the following company addresses exist:
       | company       | street           | city    | zipcode | state      |

--- a/features/step_definitions/accept_job_applications_steps.rb
+++ b/features/step_definitions/accept_job_applications_steps.rb
@@ -32,10 +32,23 @@ And(/^I click the "([^"]*)" confirmation$/) do |action|
 	find("a[href='/job_applications/#{@job_app.id}/#{action.downcase}']").click
 end 
 
-And(/^I should see "3" active applications for the job$/) do 
+And(/^I should see "([^"]*)" active applications for the job$/) do |count|
 	@app_ids = JobApplication.select(:id).where(status: 'active')
+	expect(@app_ids.count).to eq count.to_i
+end
+
+And(/^I should see "([^"]*)" application changes to accepted$/) do |email|
+	job_seeker = User.find_by_email(email).actable
+	@app_accepted = JobApplication.find_by(job_seeker: job_seeker)
+	within("#applications-#{@app_accepted.id}") { expect(page).to have_content("accepted") }
+end 
+
+# this step can only be used in a scenario that includes steps line:35 and line:42
+# which define @app_ids, @app_accepted
+And(/^other applications change to not accepted$/) do 
 	@app_ids.each do |app|
-		expect(page.find("#applications-#{app.id}")).to have_content("accept")
+		expect(page.find("#applications-#{app.id}")).
+		to have_content("not_accepted") unless app.id == @app_accepted.id
 	end
 end
 
@@ -53,18 +66,6 @@ And(/^I should see "([^"]*)" application is listed first$/) do |email|
 	within(".pagination-div > table > tbody > tr:first-child") { expect(page).to have_content("#{job_seeker.first_name}") }
 end
 
-And(/^I should see "([^"]*)" application changes to accepted$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	@app_accepted = JobApplication.find_by(job_seeker: job_seeker)
-	within("#applications-#{@app_accepted.id}") { expect(page).to have_content("accepted") }
-end 
-
-And(/^other applications change to not accepted$/) do 
-	@app_ids.each do |app|
-		expect(page.find("#applications-#{app.id}")).
-		to have_content("not_accepted") unless app.id == @app_accepted.id
-	end
-end
 
 And(/^I should see "([^"]*)" job changes to status filled/) do |job_title|
 	find("#job-status") { expect(page).to have_content("filled") }

--- a/features/step_definitions/accept_job_applications_steps.rb
+++ b/features/step_definitions/accept_job_applications_steps.rb
@@ -1,0 +1,93 @@
+And(/^I click "([^"]*)" link to job applications index page$/) do |job_title|
+	job = Job.find_by(title: "#{job_title}")
+	find("a[href='/jobs/#{job.id}/applications']").click 
+end
+
+And(/^I click "([^"]*)" link to job show page$/) do |job_title|
+	job = Job.find_by(title: "#{job_title}")
+	find("#applications-my-applied a[href='/jobs/#{job.id}']").click
+end
+
+And(/^I click "([^"]*)" link to "([^"]*)'s" job application show page$/) do |email, js_name|
+	job_seeker = User.find_by_email(email).actable
+	@job_app = JobApplication.find_by(job_seeker: job_seeker)
+	find("a[href='/job_applications/#{@job_app.id}']").click
+end
+
+And(/^I accept "([^"]*)" application$/) do |email|
+	job_seeker = User.find_by_email(email).actable
+	@job_app = JobApplication.find_by(job_seeker: job_seeker)
+	find("#applications-#{@job_app.id} a.accept_link").click
+end
+
+And(/^I should see an "([^"]*)" confirmation$/) do |action|
+	expect(page).to have_content("Are you sure you want 
+ 		         to #{action} the following application: 
+ 		         		 applicant's name: #{@job_app.job_seeker.full_name(last_name_first: false)}
+                 job title:  #{@job_app.job.title}
+                 company job id: #{@job_app.job.company_job_id}")
+end
+
+And(/^I click the "([^"]*)" confirmation$/) do |action|
+	find("a[href='/job_applications/#{@job_app.id}/#{action.downcase}']").click
+end 
+
+And(/^I should see "3" active applications for the job$/) do 
+	@app_ids = JobApplication.select(:id).where(status: 'active')
+	@app_ids.each do |app|
+		expect(page.find("#applications-#{app.id}")).to have_content("accept")
+	end
+end
+
+Then(/^I should( not)? see(?: an)? "([^"]*)" link$/) do |not_see, action|
+	if not_see
+		expect(page).not_to have_css("a.#{action.downcase}_link", text: "#{action}")
+	else
+		expect(page).to have_css("a.#{action.downcase}_link", text: "#{action}")
+	end
+end
+
+And(/^I should see "([^"]*)" application is listed first$/) do |email|
+	job_seeker = User.find_by_email(email).actable
+	job_app = JobApplication.find_by(job_seeker: job_seeker)
+	within(".pagination-div > table > tbody > tr:first-child") { expect(page).to have_content("#{job_seeker.first_name}") }
+end
+
+And(/^I should see "([^"]*)" application changes to accepted$/) do |email|
+	job_seeker = User.find_by_email(email).actable
+	@app_accepted = JobApplication.find_by(job_seeker: job_seeker)
+	within("#applications-#{@app_accepted.id}") { expect(page).to have_content("accepted") }
+end 
+
+And(/^other applications change to not accepted$/) do 
+	@app_ids.each do |app|
+		expect(page.find("#applications-#{app.id}")).
+		to have_content("not_accepted") unless app.id == @app_accepted.id
+	end
+end
+
+And(/^I should see "([^"]*)" job changes to status filled/) do |job_title|
+	find("#job-status") { expect(page).to have_content("filled") }
+end
+
+And(/^I should see my application for "([^"]*)" show status "([^"]*)"$/) do |job_title, status|
+	job = Job.find_by(title: "#{job_title}")
+	job_app = JobApplication.find_by(job: job)
+	expect(page.find("#applications-#{job_app.id}")).to have_content("#{status}")
+end
+
+And(/^I am returned to "([^"]*)" job application index page$/) do |job_title|
+	expect(page.find("#job-title")).to have_content("#{job_title}")
+end
+
+And(/^I should see "(?:[^"]*)" show status "([^"]*)"$/) do |status|
+	expect(page.find("#job-status")).to have_content("#{status}")
+end 
+
+And(/^I return to my "([^"]*)" home page$/) do |email|
+	job_seeker = User.find_by_email(email).actable
+	role = job_seeker.class.to_s.underscore
+	visit "/#{role}s/#{job_seeker.id}/home"
+end
+
+	  

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -196,7 +196,12 @@ Given(/^the following job applications exist:$/) do |table|
     job = Job.find_by_title(hash['job title'])
     job_seeker = User.find_by_email(hash['job seeker']).actable
 
-    JobApplication.create!(job: job, job_seeker: job_seeker)
+    unless hash[:status]
+      JobApplication.create!(job: job, job_seeker: job_seeker)
+    else
+      FactoryGirl.create(:job_application, job: job, job_seeker: job_seeker,
+                         status: hash[:status])
+    end
   end
 end
 

--- a/features/view_job_application.feature
+++ b/features/view_job_application.feature
@@ -1,0 +1,47 @@
+Feature: View job application status
+
+	As a job seeker person
+	I want to view my job application status
+
+Background: data is added to database 
+
+	Given the default settings are present
+
+  Given the following companies exist:
+  	| agency  | name         | website     | phone        | email            | ein        | status |
+  	| MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
+
+  Given the following company people exist:
+  	| company      | role  | first_name | last_name | email            | password  | phone        |
+  	| Widgets Inc. | CA    | Cane       | Daniel    | cane@widgets.com | qwerty123 | 555-222-3334 |
+
+  Given the following jobseeker exist:
+  	| first_name | last_name | email         | phone        | password  | password_confirmation | year_of_birth | job_seeker_status  |
+  	| John       | Seeker    | john@seek.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+  	| July       | Seeker    | july@seek.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+
+  Given the following jobs exist:
+    | title        | company_job_id | shift | fulltime | description | company      | creator        | status  |
+    | hr assistant | KRK01K         | Day		| true     | internship  | Widgets Inc. | cane@widgets.com | filled  |
+    | hr associate | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com | filled  |
+    
+	Given the following job applications exist:
+		| job title 	 | job seeker 	 | status 			|
+		| hr assistant | july@seek.com | accepted 		|
+		| hr associate | july@seek.com | not_accepted |
+		| hr associate | john@seek.com | accepted     |
+
+  @javascript 
+  Scenario: Successful and unsuccessful application for job seeker
+    Given I am on the home page
+    And I login as "july@seek.com" with password "qwerty123"
+    And I wait 1 second
+    And I should see my application for "hr assistant" show status "Accepted"
+    Then I click "hr assistant" link to job show page
+    And I should see "hr assistant" show status "filled"
+    And I should not see "Click Here To Apply Online"
+    Then I return to my "july@seek.com" home page 
+    And I should see my application for "hr associate" show status "NotAccepted"
+    Then I click "hr associate" link to job show page
+    And I should see "hr associate" show status "filled"
+    And I should not see "Click Here To Apply Online"

--- a/features/view_job_application.feature
+++ b/features/view_job_application.feature
@@ -8,8 +8,8 @@ Background: data is added to database
 	Given the default settings are present
 
   Given the following companies exist:
-  	| agency  | name         | website     | phone        | email            | ein        | status |
-  	| MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | 12-3456789 | Active |
+    | agency  | name         | website     | phone        | email            | job_email        | ein        | status |
+    | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@widgets.com | corp@widgets.com | 12-3456789 | Active |
 
   Given the following company people exist:
   	| company      | role  | first_name | last_name | email            | password  | phone        |

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+include ServiceStubHelpers::Cruncher
+
+RSpec.describe JobApplicationsController, type: :controller do
+
+	describe 'PATCH accept' do
+		let(:job) { FactoryGirl.create(:job) }
+		let(:job_seeker) { FactoryGirl.create(:job_seeker) }
+		let(:invalid_application) { FactoryGirl.create(:job_application, job: job, job_seeker: job_seeker, status: 'accepted')}
+		let(:valid_application) { FactoryGirl.create(:job_application, job: job, job_seeker: job_seeker) }
+
+		context 'Invalid Job Application' do
+			before (:each) do
+				stub_cruncher_authenticate
+      	stub_cruncher_job_create
+				patch :accept, id: invalid_application
+	    end
+	    it 'look for the invalid application' do
+	    	expect(assigns(:job_application)).to eq invalid_application
+	    end
+			it 'show a flash[:alert]' do
+				expect(flash[:alert]).to eq "Invalid action on inactive job application."
+			end
+			it 'redirect to the specific job application index page' do
+				expect(response).to redirect_to(applications_job_url(invalid_application.job))
+			end
+		end
+
+		context 'Valid Job Application' do
+			before (:each) do
+				stub_cruncher_authenticate
+      	stub_cruncher_job_create
+				expect_any_instance_of(JobApplication).to receive(:accept)
+				patch :accept, id: valid_application
+			end
+			it 'show a flash[:info]' do
+				expect(flash[:info]).to eq "Job application accepted."
+			end
+			it 'redirect to the specific job application index page' do
+				expect(response).to redirect_to(applications_job_url(valid_application.job))
+			end
+		end
+	end
+
+	describe 'GET show' do
+		context 'Invalid Request' do
+			it 'shows a flash[:alert]' do
+				get :show, id: anything
+				expect(flash[:alert]).to eq "Job Application Entry not found."
+			end
+		end
+	end
+end

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe NotifyEmailJob, type: :job do
       to change(Delayed::Job, :count).by(+1)
   end
 
+  it 'job application accepted event' do
+    expect{ NotifyEmailJob.set(wait: Event.delay_seconds.seconds).
+                 perform_later('job_developer@gmail.com',
+                 Event::EVT_TYPE[:APP_ACCEPTED],
+                 {name: 'Joe Newseeker', id: 1}) }.
+      to change(Delayed::Job, :count).by(+1)
+  end
+
   it 'job seeker assigned to job developer event' do
     expect{ NotifyEmailJob.set(wait: Event.delay_seconds.seconds).
                  perform_later('job_developer@gmail.com',

--- a/spec/mailers/agency_mailer_spec.rb
+++ b/spec/mailers/agency_mailer_spec.rb
@@ -83,6 +83,31 @@ RSpec.describe AgencyMailer, type: :mailer do
     end
   end
 
+  describe 'Job Application accepted' do
+    let(:job) { FactoryGirl.create(:job) }
+    let(:job_developer) { FactoryGirl.create(:job_developer) }
+    let(:job_seeker) { FactoryGirl.create(:job_seeker) } 
+    let(:app) { FactoryGirl.create(:job_application, job_seeker: job_seeker, job: job) }
+    let(:mail) { AgencyMailer.job_application_accepted(job_developer.email, app) }
+
+    before :each do
+      stub_cruncher_authenticate
+      stub_cruncher_job_create
+    end
+
+    it "renders the headers" do
+      expect(mail.subject).to eq 'Job application accepted'
+      expect(mail.to).to eq(["#{job_developer.email}"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+    it "renders the body" do
+      expect(mail).to have_body_text("A job application is accepted:")
+    end
+    it "includes link to show job application" do
+      expect(mail).to have_body_text(/#{application_url(id: 1)}/)
+    end
+  end
+
   describe 'Job seeker assigned to job developer' do
     let(:job_developer) { FactoryGirl.create(:job_developer) }
     let(:job_seeker)    { FactoryGirl.create(:job_seeker) }

--- a/spec/mailers/previews/agency_mailer_preview.rb
+++ b/spec/mailers/previews/agency_mailer_preview.rb
@@ -24,6 +24,17 @@ class AgencyMailerPreview < ActionMailer::Preview
     AgencyMailer.job_seeker_applied(agency_person.email, application)
   end
 
+  def job_application_accepted
+    job_seeker    = User.find_by_email('tom@gmail.com').actable
+    agency_person = User.find_by_email('chet@metplus.org').actable
+    company       = Company.find_by_email('contact@widgets.com')
+    job           = company.jobs.first
+    job.apply job_seeker
+    application   = job.last_application_by_job_seeker(job_seeker)
+
+    AgencyMailer.job_application_accepted(agency_person.email, application)
+  end
+
   def job_seeker_assigned_jd
     job_seeker    = JobSeeker.first
     agency_person = AgencyPerson.first

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -65,4 +65,56 @@ RSpec.describe JobApplication, type: :model do
       expect(subject.status_name).to eq 'NotAccepted'
     end
   end
+
+  describe '#active?' do
+    let(:active_job) { FactoryGirl.create(:job) }
+    let(:inactive_job) { FactoryGirl.create(:job, status: Job::STATUS[:FILLED])}
+    let(:job_seeker) { FactoryGirl.create(:job_seeker) }
+    let(:valid_application) { FactoryGirl.create(:job_application, 
+                              job: active_job, job_seeker: job_seeker) }
+    let(:invalid_application1) { FactoryGirl.create(:job_application, 
+                                 job: inactive_job, job_seeker: job_seeker) }
+    let(:invalid_application2) { FactoryGirl.create(:job_application, 
+                                 job: active_job, job_seeker: job_seeker, 
+                                 status: 'accepted') }
+
+    context 'with active job and active application status' do
+      it 'returns true' do
+        expect(valid_application.active?).to be true
+      end
+    end
+    context 'with inactive job and active application status' do
+      it 'returns false' do
+        expect(invalid_application1.active?).to be false
+      end
+    end
+    context 'with inactive job and inactive application status' do
+      it 'returns false' do
+        expect(invalid_application2.active?).to be false
+      end
+    end
+  end
+
+  describe '#accept' do
+    let(:active_job) { FactoryGirl.create(:job) }
+    let(:job_seeker1) { FactoryGirl.create(:job_seeker) }
+    let(:job_seeker2) { FactoryGirl.create(:job_seeker) }
+    let(:application1) { FactoryGirl.create(:job_application, 
+                         job: active_job, job_seeker: job_seeker1) }
+    let(:application2) { FactoryGirl.create(:job_application, 
+                         job: active_job, job_seeker: job_seeker2) }
+
+    it 'updates the selected application status to be accepted' do
+      expect { application1.accept }.to change{application1.status}.from('active').to('accepted')
+    end
+    it 'updates unselected application status to be not accepted' do
+      expect { application1.accept }.to change{application1.job.job_applications.
+                                               find(application2.id).status}.
+                                               from('active').to('not_accepted')
+    end
+    it 'updates the selected job status to be filled' do
+      expect { application1.accept }.to change{application1.job.status}.from('active').to('filled')
+    end
+  end
+    
 end


### PR DESCRIPTION
Company person Accept Job Application
- add 'accept' link
- add confirmation for accept
- notification event for job developer after accept 

Question:
- In Job applications list, there is a column for 'applied' which refer to 'updated_at'. This info might not be accurate because updating the job application status to 'accepted' will change the 'updated_at'. 
- Notice that in email preview, error happens (looks broken) when a logged-out user click the link to view job application show page. Is it a real bug or can be ignore?
- what is this error refer to in cucumber test? It will disappear by re-running
![screen shot 2016-08-09 at 17 19 03](https://cloud.githubusercontent.com/assets/16623014/17522402/7355e856-5e89-11e6-9265-f81fae5bbb3b.png)
