### PR TITLE
Closes AgileVentures/MetPlus_tracker#397

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,4 +119,5 @@ group :production do
   gem 'pg'
   gem 'rails_12factor'
   gem 'puma'
+  gem 'airbrake', '~> 5.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    airbrake (5.4.4)
+      airbrake-ruby (~> 1.4)
+    airbrake-ruby (1.4.4)
     arel (6.0.3)
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
@@ -337,6 +340,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record-acts_as
+  airbrake (~> 5.4)
   bcrypt (~> 3.1.7)
   bootstrap-will_paginate
   bullet


### PR DESCRIPTION
this adds the gem 'airbrake' to the :production group in Gemfile.

This gem allows us to see more detailed log/error information in apps deployed on Heroku.