### PR TITLE
Closes AgileVentures/MetPlus_tracker#400

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -3,6 +3,8 @@ class JobApplication < ActiveRecord::Base
   belongs_to :job
   enum status: [:active, :accepted, :not_accepted]
 
+  has_many :status_changes, as: :entity, dependent: :destroy
+
   def status_name
     status.to_s.camelcase
   end
@@ -14,7 +16,7 @@ class JobApplication < ActiveRecord::Base
   def accept
     accepted!
 		reject_applications = job.job_applications.where.not(id: self.id)
-		reject_applications.each do |application| 
+		reject_applications.each do |application|
 			application.not_accepted!
 		end
     job.filled

--- a/app/models/status_change.rb
+++ b/app/models/status_change.rb
@@ -19,16 +19,20 @@ class StatusChange < ActiveRecord::Base
                      status_change_to: entity.class.statuses[to_status])
   end
 
-  def self.status_change_time(entity, to_status)
-    # Returns time when entity transitioned to specific status.
-    # Returns nil if to_status is not found.
-    # NOTE: this assumes that an entity assume the specified status
-    #       only once in its life cycle.  If this changes, this code
-    #       must be changed as well.
+  def self.status_change_time(entity, to_status, which = :latest)
+    # Returns time(s) when entity transitioned to specific status.
+    # If 'which' == :latest, returns latest time that entity status == to_status
+    # If 'which' == :all, returns an array of times that entity status
+    #             == to_status (in ascending order)
+    # Returns nil if to_status is not found
+    # Raises exception if 'which' is invalid
 
-    change = entity.status_changes.
-        where(status_change_to: entity.class.statuses[to_status])[0]
-    return change.created_at if change
-    nil
+    change_times = entity.status_changes.
+        where(status_change_to: entity.class.statuses[to_status]).
+              order(:created_at).pluck(:created_at)
+
+    return change_times.last if which == :latest
+    return change_times      if which == :all
+    raise ArgumentError.new("Invalid 'which' argument")
   end
 end

--- a/app/models/status_change.rb
+++ b/app/models/status_change.rb
@@ -1,0 +1,34 @@
+class StatusChange < ActiveRecord::Base
+  belongs_to :entity, polymorphic: true
+
+  validates_presence_of :status_change_to
+  validates_numericality_of :status_change_to, only_integer: true,
+                            greater_than_or_equal_to: 0
+
+  validates_numericality_of :status_change_from, only_integer: true,
+                            greater_than_or_equal_to: 0,
+                            allow_nil: true
+
+  def self.update_status_history(entity, from_status, to_status)
+    # Adds a status change record for the entity.
+    # Returns a collection proxy for the status_changes if successful.
+    # Returns false if not successful.
+
+    entity.status_changes << StatusChange.
+              create(status_change_from: entity.class.statuses[from_status],
+                     status_change_to: entity.class.statuses[to_status])
+  end
+
+  def self.status_change_time(entity, to_status)
+    # Returns time when entity transitioned to specific status.
+    # Returns nil if to_status is not found.
+    # NOTE: this assumes that an entity assume the specified status
+    #       only once in its life cycle.  If this changes, this code
+    #       must be changed as well.
+
+    change = entity.status_changes.
+        where(status_change_to: entity.class.statuses[to_status])[0]
+    return change.created_at if change
+    nil
+  end
+end

--- a/db/migrate/20160816165008_create_status_changes.rb
+++ b/db/migrate/20160816165008_create_status_changes.rb
@@ -1,0 +1,12 @@
+class CreateStatusChanges < ActiveRecord::Migration
+  def change
+    create_table :status_changes do |t|
+      t.integer :status_change_to
+      t.integer :status_change_from, null: true
+      
+      t.references :entity, polymorphic: true, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/features/accept_job_application.feature
+++ b/features/accept_job_application.feature
@@ -3,7 +3,7 @@ Feature: Accept a job application
 	As a company person
 	I want to accept a job application
 
-Background: data is added to database 
+Background: data is added to database
 
 	Given the default settings are present
 
@@ -33,8 +33,8 @@ Background: data is added to database
 
   Given the following jobs exist:
     | title        | company_job_id | shift | fulltime | description | company      | creator          |
-    | hr manager   | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com | 
-    
+    | hr manager   | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com |
+
 	Given the following job applications exist:
 		| job title 	 | job seeker 	 | status 			|
 		| hr manager	 | john@seek.com | active 			|
@@ -46,22 +46,22 @@ Background: data is added to database
 		Given I am on the home page
 	  And I login as "cicil@widgets.com" with password "qwerty123"
 	  And I wait 1 second
-	  Then I click "hr manager" link to job applications index page 
+	  Then I click "hr manager" link to job applications index page
 	  And I should see "3" active applications for the job
 	  Then I accept "jane@seek.com" application
 	  And I should see an "accept" confirmation
 	  Then I click the "Accept" confirmation
 	  And I should see "jane@seek.com" application is listed first
-	  And I should see "jane@seek.com" application changes to accepted 
+	  And I should see "jane@seek.com" application changes to accepted
 	  And other applications change to not accepted
 	  And I should see "hr manager" job changes to status filled
 
-	@javascript
+	@selenium
 	Scenario: company admin accept a job application
 		Given I am on the home page
 	  And I login as "cane@widgets.com" with password "qwerty123"
 	  And I wait 1 second
-	  Then I click "hr manager" link to job applications index page 
+	  Then I click "hr manager" link to job applications index page
 	  And I should see "3" active applications for the job
 	  Then I click "june@seek.com" link to "June's" job application show page
 	  And I should see an "Accept" link
@@ -70,7 +70,7 @@ Background: data is added to database
 	  Then I click the "Accept" confirmation
 	  And I am returned to "hr manager" job application index page
 	  And I should see "june@seek.com" application is listed first
-	  And I should see "june@seek.com" application changes to accepted 
+	  And I should see "june@seek.com" application changes to accepted
 	  And other applications change to not accepted
 	  And I should see "hr manager" job changes to status filled
 	  Then I click "june@seek.com" link to "June's" job application show page
@@ -85,7 +85,7 @@ Background: data is added to database
 	  When I am in Company Admin's browser
 	  Given I am on the home page
 	  And I login as "cane@widgets.com" with password "qwerty123"
-	  Then I click "hr manager" link to job applications index page 
+	  Then I click "hr manager" link to job applications index page
 	  And I accept "john@seek.com" application
 	  And I click the "Accept" confirmation
 
@@ -94,5 +94,3 @@ Background: data is added to database
 	  And "dave@metplus.org" should receive an email with subject "Job application accepted"
 	  Then "dave@metplus.org" opens the email
 	  And I should see "A job application is accepted:" in the email body
-	  
-

--- a/spec/factories/status_changes.rb
+++ b/spec/factories/status_changes.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :status_change do
+    status_change_to 0
+    status_change_from 1
+    entity nil
+  end
+
+end

--- a/spec/models/status_change_spec.rb
+++ b/spec/models/status_change_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe StatusChange, type: :model do
+  describe 'Fixtures' do
+    it 'should have a valid factory' do
+      expect(FactoryGirl.build(:status_change)).to be_valid
+    end
+  end
+
+  describe 'Associations' do
+    it { is_expected.to belong_to :entity }
+  end
+
+  describe 'Database schema' do
+    it { is_expected.to have_db_column :id }
+    it { is_expected.to have_db_column :status_change_from }
+    it { is_expected.to have_db_column :status_change_to }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:status_change_to) }
+    it { is_expected.to validate_numericality_of(:status_change_to).
+                  only_integer.is_greater_than_or_equal_to(0) }
+
+    it { is_expected.to validate_numericality_of(:status_change_from).
+                  only_integer.is_greater_than_or_equal_to(0).allow_nil }
+  end
+
+  describe 'Class methods' do
+    let(:ja) { FactoryGirl.create(:job_application) }
+
+    it 'adds a status change record for an entity' do
+      expect{ StatusChange.update_status_history(ja, nil, :active) }.
+            to change(StatusChange, :count).by 1
+      expect(ja.status_changes.count).to eq 1
+    end
+
+    it 'returns status change time for an entity' do
+      StatusChange.update_status_history(ja, nil, :active)
+      expect(StatusChange.status_change_time(ja, :active)).
+          to eq StatusChange.first.created_at
+    end
+  end
+
+end

--- a/spec/models/status_change_spec.rb
+++ b/spec/models/status_change_spec.rb
@@ -27,24 +27,54 @@ RSpec.describe StatusChange, type: :model do
   end
 
   describe 'Class methods' do
-    let(:ja) { FactoryGirl.create(:job_application) }
+    let(:ja1) { FactoryGirl.create(:job_application) }
+    let(:ja2) { FactoryGirl.create(:job_application) }
 
     it 'adds a status change record for an entity' do
-      expect{ StatusChange.update_status_history(ja, nil, :active) }.
+      expect{ StatusChange.update_status_history(ja1, nil, :active) }.
             to change(StatusChange, :count).by 1
-      expect(ja.status_changes.count).to eq 1
+      expect(ja1.status_changes.count).to eq 1
     end
 
     it 'returns status change time for an entity' do
-      StatusChange.update_status_history(ja, nil, :active)
+      StatusChange.update_status_history(ja1, nil, :active)
       sleep(1)
-      StatusChange.update_status_history(ja, :active, :accepted)
+      StatusChange.update_status_history(ja2, nil, :active)
+      StatusChange.update_status_history(ja1, :active, :accepted)
+      sleep(1)
+      StatusChange.update_status_history(ja2, :active, :accepted)
 
-      expect(StatusChange.status_change_time(ja, :active)).
+      expect(StatusChange.status_change_time(ja1, :active)).
           to eq StatusChange.first.created_at
 
-      expect(StatusChange.status_change_time(ja, :accepted)).
+      expect(StatusChange.status_change_time(ja1, :accepted)).
+          to eq StatusChange.third.created_at
+
+      expect(StatusChange.status_change_time(ja2, :active)).
           to eq StatusChange.second.created_at
+      expect(StatusChange.status_change_time(ja2, :accepted)).
+          to eq StatusChange.last.created_at
+    end
+
+    it 'returns an array of times for multiple occurences of status' do
+      t1 = StatusChange.update_status_history(ja1, nil, :active).
+                      last.created_at
+      t2 = StatusChange.update_status_history(ja1, :active, :accepted).
+                      last.created_at
+      t3 = StatusChange.update_status_history(ja1, :accepted, :active).
+                      last.created_at
+
+      change_times = StatusChange.status_change_time(ja1, :active, :all)
+
+      expect(change_times).to eq [t1, t3]
+    end
+
+    it 'raises exception with invalid time(s) selector' do
+      StatusChange.update_status_history(ja1, nil, :active)
+      StatusChange.update_status_history(ja1, :active, :accepted)
+
+      expect {StatusChange.status_change_time(ja1, :active, :unknown)}.
+                  to raise_error(ArgumentError, "Invalid 'which' argument")
     end
   end
 

--- a/spec/models/status_change_spec.rb
+++ b/spec/models/status_change_spec.rb
@@ -37,8 +37,14 @@ RSpec.describe StatusChange, type: :model do
 
     it 'returns status change time for an entity' do
       StatusChange.update_status_history(ja, nil, :active)
+      sleep(1)
+      StatusChange.update_status_history(ja, :active, :accepted)
+
       expect(StatusChange.status_change_time(ja, :active)).
           to eq StatusChange.first.created_at
+
+      expect(StatusChange.status_change_time(ja, :accepted)).
+          to eq StatusChange.second.created_at
     end
   end
 


### PR DESCRIPTION
# Story:
Currently we are showing timestamps for entity states based solely on the 'updated_at' timestamp for the entity. 

For instance, this code segment (from views/jobs/_job_applications.html.haml) uses the 'updated_at' field to display the time when a job application was submitted:

```
  %table.table.table-hover
    %thead
      %tr
        - application_fields(@application_type).each do |field|
          - case field
            - when :name
              %th.strong Name
            - when :js_status
              %th.strong Job Seeker Status
            - when :updated_at
              %th.strong Applied
            - when :action
              %th.strong Action
```
If the application status changes to 'accepted', or 'not_accepted', this view will show incorrect information.

This story is to design and implement a general way to track status changes for any entity with a simple status change structure (that is, when we only need to track 1) the state transitioned to (integer) and 2) the time when that transition occurred).  We get the second one for free from Rails (created_at).

# Implementation

- [ ] Design a model that will provide the structure and appropriate methods for managing state change, for example:
```
class StatusChange < ActiveRecord::Base
  belongs_to :entity, polymorphic: true

  validates_presence_of status_change_to
  validates_presence_of status_change_from, allow_nil: true
  .....
```
- [ ] Migration to add to DB.  **NOTE** - you can create the model file and the DB migration with this one command:
```
rails g model StatusChange status_change_to:integer   status_change_from:integer   entity:references{polymorphic}
```
- [ ] Rspec tests

NOTE: An entity for which this functionality is used must use an *enum* field to track status.  For instance, from the JobApplication model:
```
enum status: [:active, :accepted, :not_accepted]
```
This allows some tolerance for change in how status values are displayed to the user.  For instance, if we decide to change the first status for JobApplication from :active to :Active, this will not affect the integrity of the information maintained by StateChange.

- [ ] Add has_many status_changes association to JobApplication
  - for testing purposes
  - this model will need to be augmented to use StatusChange in order to address flaw(s) in view(s) (like the one described above)