### PR TITLE
Closes AgileVentures/MetPlus_tracker#401

### DIFF
--- a/app/controllers/concerns/job_applications_viewer.rb
+++ b/app/controllers/concerns/job_applications_viewer.rb
@@ -25,9 +25,9 @@ module JobApplicationsViewer
   end
 
   FIELDS_IN_APPLICATION_TYPE = {
-      'my-applied': [:title, :description, :company, :updated_at, :status],
-      'js-applied': [:title, :description, :company, :updated_at, :status],
-      'job-applied': [:name, :js_status, :updated_at, :action]
+      'my-applied': [:title, :description, :company, :applied_at, :status],
+      'js-applied': [:title, :description, :company, :applied_at, :status],
+      'job-applied': [:name, :js_status, :applied_at, :action]
   }
 
   def application_fields application_type

--- a/app/views/agency_people/_job_seekers.html.haml
+++ b/app/views/agency_people/_job_seekers.html.haml
@@ -34,7 +34,8 @@
           - if js.job_applications.empty?
             %i none
           - else
-            = "#{time_ago_in_words(js.latest_application.created_at)} ago"
+            - applied_at = js.latest_application.status_change_time(:active)
+            = "#{time_ago_in_words(applied_at)} ago"
 
 = will_paginate jobseekers
 .clearfix

--- a/app/views/jobs/_applied_job_list.html.haml
+++ b/app/views/jobs/_applied_job_list.html.haml
@@ -14,7 +14,7 @@
               %th.strong Description
             - when :company
               %th.strong Company
-            - when :updated_at
+            - when :applied_at
               %th.strong Applied
             - when :status
               %th.strong Status
@@ -33,9 +33,10 @@
               - when :company
                 %td
                   = job_application.job.company.name
-              - when :updated_at
+              - when :applied_at
                 %td
-                  = "#{time_ago_in_words(job_application.updated_at, )} ago"
+                  - applied_at = job_application.status_change_time(:active)
+                  = "#{time_ago_in_words(applied_at)} ago"
               - when :status
                 %td
                   = job_application.status_name

--- a/app/views/jobs/_job_applications.html.haml
+++ b/app/views/jobs/_job_applications.html.haml
@@ -11,7 +11,7 @@
               %th.strong Name
             - when :js_status
               %th.strong Job Seeker Status
-            - when :updated_at
+            - when :applied_at
               %th.strong Applied
             - when :action
               %th.strong Action
@@ -29,13 +29,14 @@
                   = job_application.job_seeker.job_seeker_status.short_description
               - when :updated_at
                 %td
-                  = "#{time_ago_in_words(job_application.updated_at, )} ago"
+                  - applied_at = job_application.status_change_time(:active)
+                  = "#{time_ago_in_words(applied_at, )} ago"
               - when :action
                 %td
                   - if job_application.active?
-                    = link_to "accept", '#', class: "accept_link btn btn-default", 
-                      data: { "application-id" => "#{job_application.id}", 
-                              "job-title" => "#{job_application.job.title}", 
+                    = link_to "accept", '#', class: "accept_link btn btn-default",
+                      data: { "application-id" => "#{job_application.id}",
+                              "job-title" => "#{job_application.job.title}",
                               "jobSeeker" => "#{job_application.job_seeker.full_name(last_name_first: false)}",
                               "job-companyJobId" => "#{job_application.job.company_job_id}" }
                   - else

--- a/features/event_management.feature
+++ b/features/event_management.feature
@@ -99,6 +99,7 @@ Scenario: Company registration request in PETS
   Then I am in Admin's browser
   And I should see "Company: Widgets, Inc. has registered in PETS."
   Then I click the "Widgets, Inc." link and switch to the new window
+  And I wait 2 seconds
   And I should see "Company Information"
   And I should see "Widgets, Inc."
   Then I go to the tasks page

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :job_application do
     job_seeker nil
-    job nil
+    job
     status :active
   end
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe JobApplication, type: :model do
     end
   end
   describe '#status_name' do
-    
+
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create
@@ -70,12 +70,12 @@ RSpec.describe JobApplication, type: :model do
     let(:active_job) { FactoryGirl.create(:job) }
     let(:inactive_job) { FactoryGirl.create(:job, status: Job::STATUS[:FILLED])}
     let(:job_seeker) { FactoryGirl.create(:job_seeker) }
-    let(:valid_application) { FactoryGirl.create(:job_application, 
+    let(:valid_application) { FactoryGirl.create(:job_application,
                               job: active_job, job_seeker: job_seeker) }
-    let(:invalid_application1) { FactoryGirl.create(:job_application, 
+    let(:invalid_application1) { FactoryGirl.create(:job_application,
                                  job: inactive_job, job_seeker: job_seeker) }
-    let(:invalid_application2) { FactoryGirl.create(:job_application, 
-                                 job: active_job, job_seeker: job_seeker, 
+    let(:invalid_application2) { FactoryGirl.create(:job_application,
+                                 job: active_job, job_seeker: job_seeker,
                                  status: 'accepted') }
 
     context 'with active job and active application status' do
@@ -99,9 +99,9 @@ RSpec.describe JobApplication, type: :model do
     let(:active_job) { FactoryGirl.create(:job) }
     let(:job_seeker1) { FactoryGirl.create(:job_seeker) }
     let(:job_seeker2) { FactoryGirl.create(:job_seeker) }
-    let(:application1) { FactoryGirl.create(:job_application, 
+    let(:application1) { FactoryGirl.create(:job_application,
                          job: active_job, job_seeker: job_seeker1) }
-    let(:application2) { FactoryGirl.create(:job_application, 
+    let(:application2) { FactoryGirl.create(:job_application,
                          job: active_job, job_seeker: job_seeker2) }
 
     it 'updates the selected application status to be accepted' do
@@ -116,5 +116,27 @@ RSpec.describe JobApplication, type: :model do
       expect { application1.accept }.to change{application1.job.status}.from('active').to('filled')
     end
   end
-    
+
+  describe 'tracking status change history' do
+    let!(:ja1) { FactoryGirl.create(:job_application) }
+
+    before(:each) do
+      sleep(1)
+      ja1.accept
+    end
+
+    it 'adds a status change record for a new application' do
+      expect{ FactoryGirl.create(:job_application) }.
+            to change(StatusChange, :count).by 1
+    end
+
+    it 'tracks status change times for an application' do
+      expect(ja1.status_change_time(:active)).
+          to eq StatusChange.first.created_at
+
+      expect(ja1.status_change_time(:accepted)).
+          to eq StatusChange.second.created_at
+    end
+  end
+
 end


### PR DESCRIPTION
# Story:

As a developer
I want to track status changes for a job application
So that I can accurately display status change times in the UI

# Implementation:

This story includes:

- [ ] Implement tracking of job application status changes via the StatusChange model.

- [ ] Check each view where job application(s) is shown, and correct the display of status change timestamp as needed (see example described in #400).

**NOTE**: Also added a wait before an unrelated cuke test (event mgmt) that causes intermittent and frequent failure in CI testing.