### PR TITLE
Closes AgileVentures/MetPlus_tracker#402

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -176,7 +176,7 @@ class JobsController < ApplicationController
 	end
 
 	def revoke
-		if @job.status == 'active' && @job.update(status: 'revoked')
+		if @job.status == 'active' && @job.revoked
 			flash[:alert] = "#{@job.title} is revoked successfully."
 			obj = Struct.new(:job, :agency)
 			Event.create(:JOB_REVOKED, obj.new(@job, Agency.first))

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -35,7 +35,7 @@ class Job < ActiveRecord::Base
   has_many :status_changes, as: :entity, dependent: :destroy
 
   after_create do
-    StatusChange.update_status_history(self, nil, :active)
+    StatusChange.update_status_history(self, :active)
   end
 
   def number_applicants
@@ -53,12 +53,12 @@ class Job < ActiveRecord::Base
 
   def filled
     update_attribute(:status, :filled)
-    StatusChange.update_status_history(self, :active, :filled)
+    StatusChange.update_status_history(self, :filled)
   end
 
   def revoked
     if update_attribute(:status, :revoked)
-      StatusChange.update_status_history(self, :active, :revoked)
+      StatusChange.update_status_history(self, :revoked)
       return true
     end
     false

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -31,11 +31,12 @@ class Job < ActiveRecord::Base
   scope :new_jobs, ->(given_time) {where("created_at > ?", given_time)}
   scope :find_by_company, ->(company) {where(:company => company)}
 
-  STATUS = {ACTIVE:  'active',
-            FILLED:  'filled',
-            REVOKED: 'revoked'}
-  validates_inclusion_of :status, :in => STATUS.values,
-       :message => "must be one of: #{STATUS.values.join(', ')}"
+  enum status: [:active, :filled, :revoked]
+  has_many :status_changes, as: :entity, dependent: :destroy
+
+  after_create do
+    StatusChange.update_status_history(self, nil, :active)
+  end
 
   def number_applicants
     job_applications.size
@@ -46,8 +47,21 @@ class Job < ActiveRecord::Base
     save!
   end
 
+  def status_change_time(status, which = :latest)
+    StatusChange.status_change_time(self, status, which)
+  end
+
   def filled
-    update_attribute(:status, STATUS[:FILLED])
+    update_attribute(:status, :filled)
+    StatusChange.update_status_history(self, :active, :filled)
+  end
+
+  def revoked
+    if update_attribute(:status, :revoked)
+      StatusChange.update_status_history(self, :active, :revoked)
+      return true
+    end
+    false
   end
 
   def last_application_by_job_seeker(job_seeker)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -6,7 +6,7 @@ class JobApplication < ActiveRecord::Base
   has_many :status_changes, as: :entity, dependent: :destroy
 
   after_create do
-    StatusChange.update_status_history(self, nil, :active)
+    StatusChange.update_status_history(self, :active)
   end
 
   def status_name
@@ -23,11 +23,11 @@ class JobApplication < ActiveRecord::Base
 
   def accept
     accepted!
-    StatusChange.update_status_history(self, :active, :accepted)
+    StatusChange.update_status_history(self, :accepted)
 		reject_applications = job.job_applications.where.not(id: self.id)
 		reject_applications.each do |application|
 			application.not_accepted!
-      StatusChange.update_status_history(application, :active, :not_accepted)
+      StatusChange.update_status_history(application, :not_accepted)
 		end
     job.filled
   end

--- a/app/models/status_change.rb
+++ b/app/models/status_change.rb
@@ -9,13 +9,21 @@ class StatusChange < ActiveRecord::Base
                             greater_than_or_equal_to: 0,
                             allow_nil: true
 
-  def self.update_status_history(entity, from_status, to_status)
+  def self.update_status_history(entity, to_status)
     # Adds a status change record for the entity.
+    # Store prior status as well as new status for reporting purposes.
+
     # Returns a collection proxy for the status_changes if successful.
     # Returns false if not successful.
 
+    if entity.status_changes.empty?
+      prior_status = nil
+    else
+      prior_status = entity.status_changes.last.status_change_to
+    end
+
     entity.status_changes << StatusChange.
-              create(status_change_from: entity.class.statuses[from_status],
+              create(status_change_from: prior_status,
                      status_change_to: entity.class.statuses[to_status])
   end
 

--- a/db/migrate/20160712184530_add_status_to_job.rb
+++ b/db/migrate/20160712184530_add_status_to_job.rb
@@ -1,6 +1,5 @@
 class AddStatusToJob < ActiveRecord::Migration
   def change
-    add_column :jobs, :status, :string,
-                      default: Job::STATUS[:ACTIVE]
+    add_column :jobs, :status, :string
   end
 end

--- a/db/migrate/20160825220149_change_job_status_to_enum.rb
+++ b/db/migrate/20160825220149_change_job_status_to_enum.rb
@@ -1,0 +1,5 @@
+class ChangeJobStatusToEnum < ActiveRecord::Migration
+  def change
+    change_column :jobs, :status, :integer, default: 0, null: false
+  end
+end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     company_job_id "KRKE12"
     shift 'Day'
     fulltime true
-    status Job::STATUS[:ACTIVE]
+    status :active
   end
 
 end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe JobApplication, type: :model do
 
   describe '#active?' do
     let(:active_job) { FactoryGirl.create(:job) }
-    let(:inactive_job) { FactoryGirl.create(:job, status: Job::STATUS[:FILLED])}
+    let(:inactive_job) { FactoryGirl.create(:job, status: :filled) }
     let(:job_seeker) { FactoryGirl.create(:job_seeker) }
     let(:valid_application) { FactoryGirl.create(:job_application,
                               job: active_job, job_seeker: job_seeker) }
@@ -118,7 +118,8 @@ RSpec.describe JobApplication, type: :model do
   end
 
   describe 'tracking status change history' do
-    let!(:ja1) { FactoryGirl.create(:job_application) }
+    let(:job)  { FactoryGirl.create(:job) }
+    let!(:ja1) { FactoryGirl.create(:job_application, job: job) }
 
     before(:each) do
       sleep(1)
@@ -126,16 +127,16 @@ RSpec.describe JobApplication, type: :model do
     end
 
     it 'adds a status change record for a new application' do
-      expect{ FactoryGirl.create(:job_application) }.
+      expect{ FactoryGirl.create(:job_application, job: job) }.
             to change(StatusChange, :count).by 1
     end
 
     it 'tracks status change times for an application' do
       expect(ja1.status_change_time(:active)).
-          to eq StatusChange.first.created_at
+          to eq StatusChange.second.created_at
 
       expect(ja1.status_change_time(:accepted)).
-          to eq StatusChange.second.created_at
+          to eq StatusChange.third.created_at
     end
   end
 

--- a/spec/models/status_change_spec.rb
+++ b/spec/models/status_change_spec.rb
@@ -42,19 +42,19 @@ RSpec.describe StatusChange, type: :model do
     let(:entity2) { TestEntity.create }
 
     it 'adds a status change record for an entity' do
-      expect{ StatusChange.update_status_history(entity1, nil, :hello) }.
+      expect{ StatusChange.update_status_history(entity1, :hello) }.
             to change(StatusChange, :count).by 1
       expect(entity1.status_changes.count).to eq 1
     end
 
     it 'returns status change time for an entity' do
-      StatusChange.update_status_history(entity1, nil, :hello)
+      StatusChange.update_status_history(entity1, :hello)
       sleep(1)
-      StatusChange.update_status_history(entity2, nil, :hello)
-      
-      StatusChange.update_status_history(entity1, :hello, :goodbye)
+      StatusChange.update_status_history(entity2, :hello)
+
+      StatusChange.update_status_history(entity1, :goodbye)
       sleep(1)
-      StatusChange.update_status_history(entity2, :hello, :still_here)
+      StatusChange.update_status_history(entity2, :still_here)
 
       expect(StatusChange.status_change_time(entity1, :hello)).
           to eq StatusChange.first.created_at
@@ -69,11 +69,11 @@ RSpec.describe StatusChange, type: :model do
     end
 
     it 'returns an array of times for multiple occurences of status' do
-      t1 = StatusChange.update_status_history(entity1, nil, :hello).
+      t1 = StatusChange.update_status_history(entity1, :hello).
                       last.created_at
-      t2 = StatusChange.update_status_history(entity1, :hello, :goodbye).
+      t2 = StatusChange.update_status_history(entity1, :goodbye).
                       last.created_at
-      t3 = StatusChange.update_status_history(entity1, :goodbye, :hello).
+      t3 = StatusChange.update_status_history(entity1, :hello).
                       last.created_at
 
       change_times = StatusChange.status_change_time(entity1, :hello, :all)
@@ -82,8 +82,8 @@ RSpec.describe StatusChange, type: :model do
     end
 
     it 'raises exception with invalid time(s) selector' do
-      StatusChange.update_status_history(entity1, nil, :hello)
-      StatusChange.update_status_history(entity1, :hello, :good_bye)
+      StatusChange.update_status_history(entity1, :hello)
+      StatusChange.update_status_history(entity1, :good_bye)
 
       expect {StatusChange.status_change_time(entity1, :hello, :unknown)}.
                   to raise_error(ArgumentError, "Invalid 'which' argument")


### PR DESCRIPTION
# Story

As a developer
I want Job status attributes to be enums
So that I have a common mechanism with other entities
And can leverage common helper code

# Implementation

This story includes:

- [ ] Convert Job instance status structure from a hash to enum

- [ ] Add status change updates, via StatusChange, at all places in the code where such status changes occur

- [ ] Check all views where job(s) attributes are displayed and determine if any of these need to be changed to use the status change tracking mechanism (see example of a view that needs to be updated for change tracking (for job application in that case))

Note: Also changed *StatusChange.update_status_history(entity, from_status to_status)* to *StatusChange.update_status_history(entity, to_status)*.