### PR TITLE
Closes AgileVentures/MetPlus_tracker#419

### DIFF
--- a/app/models/concerns/cruncher_utility.rb
+++ b/app/models/concerns/cruncher_utility.rb
@@ -1,0 +1,29 @@
+module CruncherUtility
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def process_match_results(results)
+      match_set = {}
+
+      # First level of results is a hash of specific matcher results ....
+      results.each_value do |matcher|
+        # Second level is array of object id and matching scores (hashes) ....
+        matcher.each do |match_item|
+          object_id = (match_item.has_key?('resumeId') ?
+                       match_item['resumeId'] : match_item['jobId']).to_i
+
+          # Have we seen this object from another matcher?
+          # If so, use highest score
+          if match_set[object_id]
+            match_set[object_id] = match_item['stars'] if
+            match_set[object_id] < match_item['stars']
+          else
+            match_set[object_id] = match_item['stars']
+          end
+        end
+      end
+
+      match_set.sort {|a,b| b[1] <=> a[1]}
+    end
+  end
+end

--- a/app/models/concerns/cruncher_utility.rb
+++ b/app/models/concerns/cruncher_utility.rb
@@ -2,15 +2,14 @@ module CruncherUtility
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def process_match_results(results)
+    def process_match_results(results, key_id)
       match_set = {}
 
       # First level of results is a hash of specific matcher results ....
       results.each_value do |matcher|
         # Second level is array of object id and matching scores (hashes) ....
         matcher.each do |match_item|
-          object_id = (match_item.has_key?('resumeId') ?
-                       match_item['resumeId'] : match_item['jobId']).to_i
+          object_id =  match_item[key_id].to_i
 
           # Have we seen this object from another matcher?
           # If so, use highest score

--- a/app/models/job_cruncher.rb
+++ b/app/models/job_cruncher.rb
@@ -1,5 +1,6 @@
 class JobCruncher
   include ActiveModel::Model
+  include CruncherUtility
 
   # This provides functionality that mediates between the Cruncher service and other models and controllers.
   def self.create_job(jobId, title, description)
@@ -9,38 +10,20 @@ class JobCruncher
   end
 
   def self.match_jobs(resumeId)
-    # If match exists, returns a hash of job matches where each
-    # key is job id (integer) and value is the score of the job
-    # match to the résumé (float - one digit to right of decimal point).
+    # If match exists, returns an array of job matches.  Each match
+    # is represented as an array with 2 values - the first value is
+    # the job ID, and the second the match score (a float, with
+    # one digit to right of decimal point).
     # Otherwise returns nil(in case of resume not found)
 
-    # Example return value:
-    # {3 => 2.1, 5 => 3.3, 8 => 4.7}
-    # Job (ID) 3 matched résumé with a score of 2.1, job 5 with 3.3, etc.
+    # The array is sorted by score (descending)
 
-    # Note that the results are not sorted in any order (keys or values)
+    # Example return value:
+    # [ [8, 4.7], [5, 3.3], [3, 2.1] ]
+    # Job (ID) 8 matched résumé with a score of 4.7, job 5 with 3.3, etc.
 
     match_results = CruncherService.match_jobs(resumeId)
 
-    matching_jobs = {}
-
-    # First level of results is a hash of specific matcher results ....
-    match_results.each_value do |matcher|
-      # Second level is array of job matching scores (hashes) ....
-      matcher.each do |job_match|
-        job_id = job_match['jobId'].to_i
-
-        # Have we seen this job from another matcher?
-        # If so, use highest score
-        if matching_jobs[job_id]
-          matching_jobs[job_id] = job_match['stars'] if
-          matching_jobs[job_id] < job_match['stars']
-        else
-          matching_jobs[job_id] = job_match['stars']
-        end
-      end
-    end
-
-    matching_jobs
+    self.process_match_results match_results
   end
 end

--- a/app/models/job_cruncher.rb
+++ b/app/models/job_cruncher.rb
@@ -24,6 +24,6 @@ class JobCruncher
 
     match_results = CruncherService.match_jobs(resumeId)
 
-    self.process_match_results match_results
+    self.process_match_results match_results, 'jobId'
   end
 end

--- a/app/models/resume_cruncher.rb
+++ b/app/models/resume_cruncher.rb
@@ -37,7 +37,7 @@ class ResumeCruncher
 
     match_results = CruncherService.match_resumes(job_id)
 
-    self.process_match_results match_results
+    self.process_match_results match_results, 'resumeId'
   end
 
 end

--- a/app/models/resume_cruncher.rb
+++ b/app/models/resume_cruncher.rb
@@ -22,20 +22,39 @@ class ResumeCruncher
   end
 
   def self.match_resumes(job_id)
-    # If a match exists, returns a hash of resume matches where
-    # key is the matcher id and value is the array of resume ids
-    # If no match exists, returns as an empty hash
+    # If match exists, returns a hash of résumé matches where each
+    # key is résumé id (integer) and value is the score of the résumé
+    # match to the job (float - one digit to right of decimal point).
+    # Otherwise returns nil (in case of job not found)
 
-    # Example return value from CruncherService:
-    # { "matcher2": [3, 2], "matcher1": [1, 2] }
-    # Note that the keys returned are 'matcher1' and 'matcher2'
-    # In the current version of API, we have a single matcher - Word Count
-    # In future releases, additional matchers will be implemented and
-    # the keys might also be modified to reflect the matcher used like
-    # { "expressionCruncher": [3, 2], "naiveBayes": [1, 2] }
-    # The caller can make use of the keys if required
+    # Example return value:
+    # {3 => 2.1, 5 => 3.3, 8 => 4.7}
+    # Résumé (ID) 3 matched job with a score of 2.1, résumé 5 with 3.3, etc.
 
-    CruncherService.match_resumes(job_id)
+    # Note that the results are not sorted in any order (keys or values)
+
+    match_results = CruncherService.match_resumes(job_id)
+
+    matching_resumes = {}
+
+    # First level of results is a hash of specific matcher results ....
+    match_results.each_value do |matcher|
+      # Second level is array of resume matching scores (hashes) ....
+      matcher.each do |resume_match|
+        resume_id = resume_match['resumeId'].to_i
+
+        # Have we seen this job from another matcher?
+        # If so, use highest score
+        if matching_resumes[resume_id]
+          matching_resumes[resume_id] = resume_match['stars'] if
+          matching_resumes[resume_id] < resume_match['stars']
+        else
+          matching_resumes[resume_id] = resume_match['stars']
+        end
+      end
+    end
+
+    matching_resumes
   end
 
 end

--- a/spec/models/concerns/cruncher_utility_spec.rb
+++ b/spec/models/concerns/cruncher_utility_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe CruncherUtility do
                                        {"resumeId"=>"7", "stars"=>1.7}]} }
 
   it 'processes job match results' do
-    processed_results = UtilityTester.process_match_results(job_results)
+    processed_results = UtilityTester.process_match_results(job_results, 'jobId')
     expect(processed_results.length).to be 4
     expect(processed_results).
       to eq [ [2, 5.5], [4, 4.4], [3, 3.8], [1, 1.0] ]
   end
 
   it 'processes resume match results' do
-    processed_results = UtilityTester.process_match_results(resume_results)
+    processed_results = UtilityTester.process_match_results(resume_results, 'resumeId')
     expect(processed_results.length).to be 4
     expect(processed_results).
       to eq [ [7, 4.9], [5, 3.6], [2, 2.0], [8, 1.8] ]

--- a/spec/models/concerns/cruncher_utility_spec.rb
+++ b/spec/models/concerns/cruncher_utility_spec.rb
@@ -5,11 +5,6 @@ end
 
 RSpec.describe CruncherUtility do
 
-  # create job-matching results
-  # create resume-matching results
-
-  # test: pass job results to 'process' method, compare output to expected
-
   let(:job_results) { {"matcher1"=>[{"jobId"=>"3", "stars"=>3.3},
                                     {"jobId"=>"2", "stars"=>2.2},
                                     {"jobId"=>"1", "stars"=>1.0}],

--- a/spec/models/concerns/cruncher_utility_spec.rb
+++ b/spec/models/concerns/cruncher_utility_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CruncherUtility do
                                     {"jobId"=>"1", "stars"=>1.0}],
                        "matcher2"=>[{"jobId"=>"4", "stars"=>4.4},
                                     {"jobId"=>"3", "stars"=>3.8},
-                                    {"jobId"=>"2", "stars"=>5.5}]} }
+                                    {"jobId"=>"2", "stars"=>5.0}]} }
 
   let(:resume_results) { {"matcher1"=>[{"resumeId"=>"2", "stars"=>2.0},
                                        {"resumeId"=>"7", "stars"=>4.9},
@@ -23,7 +23,7 @@ RSpec.describe CruncherUtility do
     processed_results = UtilityTester.process_match_results(job_results, 'jobId')
     expect(processed_results.length).to be 4
     expect(processed_results).
-      to eq [ [2, 5.5], [4, 4.4], [3, 3.8], [1, 1.0] ]
+      to eq [ [2, 5.0], [4, 4.4], [3, 3.8], [1, 1.0] ]
   end
 
   it 'processes resume match results' do

--- a/spec/models/concerns/cruncher_utility_spec.rb
+++ b/spec/models/concerns/cruncher_utility_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+class UtilityTester
+  include CruncherUtility
+end
+
+RSpec.describe CruncherUtility do
+
+  # create job-matching results
+  # create resume-matching results
+
+  # test: pass job results to 'process' method, compare output to expected
+
+  let(:job_results) { {"matcher1"=>[{"jobId"=>"3", "stars"=>3.3},
+                                    {"jobId"=>"2", "stars"=>2.2},
+                                    {"jobId"=>"1", "stars"=>1.0}],
+                       "matcher2"=>[{"jobId"=>"4", "stars"=>4.4},
+                                    {"jobId"=>"3", "stars"=>3.8},
+                                    {"jobId"=>"2", "stars"=>5.5}]} }
+
+  let(:resume_results) { {"matcher1"=>[{"resumeId"=>"2", "stars"=>2.0},
+                                       {"resumeId"=>"7", "stars"=>4.9},
+                                       {"resumeId"=>"5", "stars"=>3.6}],
+                          "matcher2"=>[{"resumeId"=>"8", "stars"=>1.8},
+                                       {"resumeId"=>"5", "stars"=>3.4},
+                                       {"resumeId"=>"7", "stars"=>1.7}]} }
+
+  it 'processes job match results' do
+    processed_results = UtilityTester.process_match_results(job_results)
+    expect(processed_results.length).to be 4
+    expect(processed_results).
+      to eq [ [2, 5.5], [4, 4.4], [3, 3.8], [1, 1.0] ]
+  end
+
+  it 'processes resume match results' do
+    processed_results = UtilityTester.process_match_results(resume_results)
+    expect(processed_results.length).to be 4
+    expect(processed_results).
+      to eq [ [7, 4.9], [5, 3.6], [2, 2.0], [8, 1.8] ]
+  end
+
+end

--- a/spec/models/resume_spec.rb
+++ b/spec/models/resume_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+include ServiceStubHelpers::Cruncher
 
 RSpec.describe Resume, type: :model do
   describe 'Fixtures' do
@@ -17,12 +18,8 @@ RSpec.describe Resume, type: :model do
 
     it 'is valid with all required fields' do
 
-      stub_request(:post, CruncherService.service_url + '/authenticate').
-          to_return(body: "{\"token\": \"12345\"}", status: 200,
-          :headers => {'Content-Type'=> 'application/json'})
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
-          to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,
-          :headers => {'Content-Type'=> 'application/json'})
+      stub_cruncher_authenticate
+      stub_cruncher_file_upload
 
       file = fixture_file_upload('files/Janitor-Resume.doc')
       resume = Resume.new(file_name: 'testfile.doc',
@@ -54,16 +51,11 @@ RSpec.describe Resume, type: :model do
     let(:job_seeker) {FactoryGirl.create(:job_seeker)}
 
     before(:each) do
-      stub_request(:post, CruncherService.service_url + '/authenticate').
-          to_return(body: "{\"token\": \"12345\"}", status: 200,
-          :headers => {'Content-Type'=> 'application/json'})
+      stub_cruncher_authenticate
+      stub_cruncher_file_upload
     end
 
     it 'succeeds with valid model and file type' do
-
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
-          to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,
-          :headers => {'Content-Type'=> 'application/json'})
 
       file = fixture_file_upload('files/Admin-Assistant-Resume.pdf')
       resume = Resume.new(file: file,
@@ -74,10 +66,6 @@ RSpec.describe Resume, type: :model do
     end
 
     it 'fails with invalid model and valid file type' do
-
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
-          to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,
-          :headers => {'Content-Type'=> 'application/json'})
 
       file = fixture_file_upload('files/Admin-Assistant-Resume.pdf')
       resume = Resume.new(file: file,
@@ -91,9 +79,6 @@ RSpec.describe Resume, type: :model do
 
     it 'fails with valid model and invalid file type' do
 
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
-          to_raise(RuntimeError)
-
       file = fixture_file_upload('files/Test File.zzz')
       resume = Resume.new(file: file,
                           file_name: 'Test File.zzz',
@@ -103,9 +88,6 @@ RSpec.describe Resume, type: :model do
     end
 
     it 'fails with invalid model and invalid file type' do
-
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
-          to_raise(RuntimeError)
 
       file = fixture_file_upload('files/Test File.zzz')
       resume = Resume.new(file: file,

--- a/spec/services/cruncher_service_spec.rb
+++ b/spec/services/cruncher_service_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe CruncherService, type: :request do
   let(:testfile_wordxml) {'files/Sales-Manager-Resume.docx'}
 
   let(:download_result) {RestClient.get(CruncherService.service_url +
-        '/curriculum/1',
+        '/resume/1',
         'X-Auth-Token' => JSON.parse(auth_result)['token'])}
 
   let(:upload_result) {RestClient.post(CruncherService.service_url +
-        '/curriculum/upload',
+        '/resume/upload',
       { 'file'   => fixture_file_upload(testfile_pdf),
         'name'   => testfile_pdf,
         'userId' => 'test_id' },
@@ -40,7 +40,7 @@ RSpec.describe CruncherService, type: :request do
         )}
 
   let(:match_resumes_result) { RestClient.get(CruncherService.service_url +
-          '/curriculum/match/1',
+          '/resume/match/1',
         { 'Accept': 'application/json',
           'X-Auth-Token': JSON.parse(auth_result)['token'] }
         )}

--- a/spec/services/job_cruncher_spec.rb
+++ b/spec/services/job_cruncher_spec.rb
@@ -25,9 +25,12 @@ RSpec.describe JobCruncher, type: :model do
   end
 
   describe 'match jobs' do
-    it 'returns the matching jobs for a valid request' do
+    it 'returns hash of matching jobs for a valid request' do
       stub_cruncher_match_jobs
-      expect { JobCruncher.match_jobs(1).not_to be nil }
+      results = JobCruncher.match_jobs(1)
+      expect(results).not_to be nil
+      expect(results.class).to be Hash
+      expect(results[3]).to be 4.7
     end
 
     it 'returns nil in case of a wrong resume id' do

--- a/spec/services/job_cruncher_spec.rb
+++ b/spec/services/job_cruncher_spec.rb
@@ -25,12 +25,15 @@ RSpec.describe JobCruncher, type: :model do
   end
 
   describe 'match jobs' do
-    it 'returns hash of matching jobs for a valid request' do
+    it 'returns array of job matches for a valid request' do
       stub_cruncher_match_jobs
       results = JobCruncher.match_jobs(1)
       expect(results).not_to be nil
-      expect(results.class).to be Hash
-      expect(results[3]).to be 4.7
+      expect(results.class).to be Array
+      expect(results[0][0]).to be 3
+      expect(results[0][1]).to be 4.7
+      expect(results[2][0]).to be 6
+      expect(results[2][1]).to be 3.4
     end
 
     it 'returns nil in case of a wrong resume id' do

--- a/spec/services/resume_cruncher_spec.rb
+++ b/spec/services/resume_cruncher_spec.rb
@@ -48,10 +48,12 @@ RSpec.describe ResumeCruncher, type: :model do
 
   describe 'match resumes' do
 
-    it 'returns success' do
-
+    it 'returns hash of matching resumes for a valid request' do
       stub_cruncher_match_resumes
-      expect(ResumeCruncher.match_resumes(1)).not_to be nil
+      results = ResumeCruncher.match_resumes(1)
+      expect(results).not_to be nil
+      expect(results.class).to be Hash
+      expect(results[7]).to be 4.9
     end
 
   end

--- a/spec/services/resume_cruncher_spec.rb
+++ b/spec/services/resume_cruncher_spec.rb
@@ -48,12 +48,17 @@ RSpec.describe ResumeCruncher, type: :model do
 
   describe 'match resumes' do
 
-    it 'returns hash of matching resumes for a valid request' do
+    it 'returns array of résumé matches for a valid request' do
       stub_cruncher_match_resumes
       results = ResumeCruncher.match_resumes(1)
       expect(results).not_to be nil
-      expect(results.class).to be Hash
-      expect(results[7]).to be 4.9
+      expect(results.class).to be Array
+      expect(results[0][0]).to be 7
+      expect(results[0][1]).to be 4.9
+      expect(results[1][0]).to be 5
+      expect(results[1][1]).to be 3.8
+      expect(results[2][0]).to be 2
+      expect(results[2][1]).to be 2.0
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ require 'webmock/rspec'
 # WebMock.disable!
 
 #  This allows non-mocked external service calls to proceed:
-# WebMock.allow_net_connect!
+WebMock.allow_net_connect!
 
 CodeClimate::TestReporter.start
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ require 'webmock/rspec'
 # WebMock.disable!
 
 #  This allows non-mocked external service calls to proceed:
-WebMock.allow_net_connect!
+# WebMock.allow_net_connect!
 
 CodeClimate::TestReporter.start
 RSpec.configure do |config|

--- a/spec/support/service_stub_helpers.rb
+++ b/spec/support/service_stub_helpers.rb
@@ -72,9 +72,12 @@ module ServiceStubHelpers
     def stub_cruncher_match_jobs
 
       body_json = JSON.generate({"resultCode"=>"SUCCESS", "message"=>"Success",
-              "jobs"=>{"matcher1"=>[{"jobId"=>"3", "stars"=>4.7},
-                                    {"jobId"=>"2", "stars"=>3.8},
-                                    {"jobId"=>"6", "stars"=>3.2}]}})
+              "jobs"=>{"matcher1"=>[{"jobId"=>"2", "stars"=>3.8},
+                                    {"jobId"=>"3", "stars"=>4.7},
+                                    {"jobId"=>"6", "stars"=>3.2}],
+                       "matcher2"=>[{"jobId"=>"8", "stars"=>2.8},
+                                    {"jobId"=>"9", "stars"=>2.9},
+                                    {"jobId"=>"6", "stars"=>3.4}]}})
 
       stub_request(:get, CruncherService.service_url + '/job/match/1').
         to_return(body: body_json, status:200,
@@ -89,9 +92,12 @@ module ServiceStubHelpers
 
     def stub_cruncher_match_resumes
       body_json = JSON.generate({"resultCode"=>"SUCCESS", "message"=>"Success",
-              "resumes"=>{"matcher1"=>[{"resumeId"=>"2", "stars"=>2.0},
+           "resumes"=>{"matcher1"=>[{"resumeId"=>"2", "stars"=>2.0},
                                     {"resumeId"=>"7", "stars"=>4.9},
-                                    {"resumeId"=>"5", "stars"=>3.6}]}})
+                                    {"resumeId"=>"5", "stars"=>3.6}],
+                       "matcher2"=>[{"resumeId"=>"8", "stars"=>1.8},
+                                    {"resumeId"=>"5", "stars"=>3.8},
+                                    {"resumeId"=>"6", "stars"=>1.7}]}})
 
       stub_request(:get, CruncherService.service_url + '/resume/match/1').
           to_return(body: body_json, status: 200,

--- a/spec/support/service_stub_helpers.rb
+++ b/spec/support/service_stub_helpers.rb
@@ -17,30 +17,30 @@ module ServiceStubHelpers
           to_raise(RuntimeError)
     end
     def stub_cruncher_file_upload
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
+      stub_request(:post, CruncherService.service_url + '/resume/upload').
           to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,
           :headers => {'Content-Type'=> 'application/json'})
     end
     def stub_cruncher_file_upload_retry_auth
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
+      stub_request(:post, CruncherService.service_url + '/resume/upload').
           to_raise(RestClient::Unauthorized).then.
           to_return(body: "{\"resultCode\":\"SUCCESS\"}", status: 200,
           :headers => {'Content-Type'=> 'application/json'})
     end
     def stub_cruncher_file_upload_error
-      stub_request(:post, CruncherService.service_url + '/curriculum/upload').
+      stub_request(:post, CruncherService.service_url + '/resume/upload').
           to_raise(RuntimeError)
     end
     def stub_cruncher_file_download(testfile)
       file = fixture_file_upload(testfile)
 
-      stub_request(:get, /#{CruncherService.service_url + "/curriculum/"}\d+/).
+      stub_request(:get, /#{CruncherService.service_url + "/resume/"}\d+/).
           to_return(body: file.read, status: 200,
           :headers => {'Content-Disposition'=>
                         'inline; filename="Admin-Assistant-Resume.pdf"'})
     end
     def stub_cruncher_file_download_notfound
-      stub_request(:get, CruncherService.service_url + '/curriculum/2').
+      stub_request(:get, CruncherService.service_url + '/resume/2').
           to_return(body: "{\"resultCode\":\"RESUME_NOT_FOUND\",
                             \"message\":\"Unable to find the user '2'\"}",
                     status: 200)
@@ -48,7 +48,7 @@ module ServiceStubHelpers
     def stub_cruncher_file_download_retry_auth(testfile)
       file = fixture_file_upload(testfile)
 
-      stub_request(:get, CruncherService.service_url + '/curriculum/1').
+      stub_request(:get, CruncherService.service_url + '/resume/1').
           to_raise(RestClient::Unauthorized).then.
           to_return(body: file.read, status: 200,
           :headers => {'Content-Disposition'=>
@@ -70,10 +70,17 @@ module ServiceStubHelpers
     end
 
     def stub_cruncher_match_jobs
+
+      body_json = JSON.generate({"resultCode"=>"SUCCESS", "message"=>"Success",
+              "jobs"=>{"matcher1"=>[{"jobId"=>"3", "stars"=>4.7},
+                                    {"jobId"=>"2", "stars"=>3.8},
+                                    {"jobId"=>"6", "stars"=>3.2}]}})
+
       stub_request(:get, CruncherService.service_url + '/job/match/1').
-        to_return(body: "{\"resultCode\": \"SUCCESS\", \"jobs\":\"{}\"}", status:200,
+        to_return(body: body_json, status:200,
         headers: {'Content-Type': 'application/json'})
     end
+
     def stub_cruncher_match_jobs_fail(resultCode)
       stub_request(:get, CruncherService.service_url + '/job/match/1').
         to_return(body: "{\"resultCode\": \"#{resultCode}\"}", status:200,
@@ -81,9 +88,15 @@ module ServiceStubHelpers
     end
 
     def stub_cruncher_match_resumes
-      stub_request(:get, CruncherService.service_url + '/curriculum/match/1').
-          to_return(body: "{ \"resultCode\":\"SUCCESS\", \"resumes\":{}}", status: 200,
+      body_json = JSON.generate({"resultCode"=>"SUCCESS", "message"=>"Success",
+              "resumes"=>{"matcher1"=>[{"resumeId"=>"2", "stars"=>2.0},
+                                    {"resumeId"=>"7", "stars"=>4.9},
+                                    {"resumeId"=>"5", "stars"=>3.6}]}})
+
+      stub_request(:get, CruncherService.service_url + '/resume/match/1').
+          to_return(body: body_json, status: 200,
           headers: { 'Content-Type': 'application/json' })
+
     end
 
   end


### PR DESCRIPTION
# Story:

The cruncher API endpoint has been changed to accommodate matching of a résumé to jobs, and provide a matching score (1 to 5) for each matched job.

The cruncher API endpoint has been changed to accommodate matching of a job to résumés, and provide a matching score (1 to 5) for each matched résumé.

# Implementation:

- [ ] In `cruncher_service.rb` update these methods:
  - [ ] `self.match_jobs(resume_id)`
  - [ ] `self.match_resumes(job_id)`

- [ ] In `job_cruncher.rb`:
  - [ ] Change comments to explain to the developer the return value
  - [ ] Call utility method to process match results

- [ ] In `resume_cruncher.rb`:
  - [ ] Change comments to explain to the developer the return value
  - [ ] Call utility method to process match results

- [ ] Add `models/concerns/cruncher_utility.rb`
  - [ ] Add class method to process match results and return array of ordered matches

- [ ] Add/update rspec tests as needed

**Note** - also updated `resume_spec.rb` with stub methods, replacing in-place stubs.

