### PR TITLE
Closes AgileVentures/MetPlus_tracker#440

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,25 @@
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+Style/BlockDelimiters:
+  Enabled: true
+
+Style/MultilineBlockLayout:
+  Enabled: true
+
+Style/BlockEndNewline:
+  Enabled: true
+
+Style/ClosingParenthesisIndentation:
+  Enabled: true
+
+Style/Tab:
+  Enabled: true
+
+Metrics/LineLength:
+  Description: 'Limit lines to 80 characters.'
+  StyleGuide: '#80-character-limits'
+  Enabled: true
+
+AllCops:
+  DisabledByDefault: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,25 +1,2 @@
 Style/StringLiterals:
   EnforcedStyle: single_quotes
-
-Style/BlockDelimiters:
-  Enabled: true
-
-Style/MultilineBlockLayout:
-  Enabled: true
-
-Style/BlockEndNewline:
-  Enabled: true
-
-Style/ClosingParenthesisIndentation:
-  Enabled: true
-
-Style/Tab:
-  Enabled: true
-
-Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: '#80-character-limits'
-  Enabled: true
-
-AllCops:
-  DisabledByDefault: true

--- a/app/controllers/concerns/job_applications_viewer.rb
+++ b/app/controllers/concerns/job_applications_viewer.rb
@@ -1,32 +1,21 @@
 module JobApplicationsViewer
   extend ActiveSupport::Concern
 
-  def display_job_applications application_type, per_page=10,
-                               js_id=nil, job_id=nil, company_id=nil
+  def display_job_applications application_type, per_page=10, id
 
     case application_type
-    when 'my-applied'
-      return JobApplication.paginate(page: params[:applications_page],
-               :per_page => per_page).where(job_seeker_id: pets_user.id)
-    when 'js-applied'
-      if company_id
-        return JobApplication.paginate(page: params[:applications_page],
-               :per_page => per_page).where(job_seeker_id: js_id).
-                          joins(:job).where('jobs.company_id = ?', company_id)
-      else
-        return JobApplication.paginate(page: params[:applications_page],
-               :per_page => per_page).where(job_seeker_id: js_id)
-      end
+    when 'job_seeker'
+      return JobApplication.paginate(page: params[:applications_page], 
+        :per_page => per_page).where(job_seeker: id) 
     when 'job-applied'
       return JobApplication.paginate(page: params[:applications_page],
-               :per_page => per_page).where(job: job_id).
+               :per_page => per_page).where(job: id).
                includes(:job_seeker).order(:status)
     end
   end
 
   FIELDS_IN_APPLICATION_TYPE = {
-      'my-applied': [:title, :description, :company, :applied_at, :status],
-      'js-applied': [:title, :description, :company, :applied_at, :status],
+      'job_seeker': [:title, :description, :company, :applied_at, :status],
       'job-applied': [:name, :js_status, :applied_at, :action]
   }
 

--- a/app/controllers/concerns/job_applications_viewer.rb
+++ b/app/controllers/concerns/job_applications_viewer.rb
@@ -5,6 +5,11 @@ module JobApplicationsViewer
 
     case application_type
     when 'job_seeker'
+      if pets_user.is_a?(CompanyPerson)
+        return JobApplication.paginate(page: params[:applications_page],
+          :per_page => per_page).where(job_seeker: id).    
+          joins(:job).where('jobs.company_id = ?', pets_user.company_id)
+      end
       return JobApplication.paginate(page: params[:applications_page], 
         :per_page => per_page).where(job_seeker: id) 
     when 'job-applied'

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -1,8 +1,7 @@
 class JobApplicationsController < ApplicationController
-	
   include JobApplicationsViewer
 
-	before_action :find_application, except: :list
+  before_action :find_application, except: :list
 
 	def accept
 		unless @job_application.active?

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -1,6 +1,6 @@
 class JobApplicationsController < ApplicationController
 	
-	include JobApplicationsViewer
+  include JobApplicationsViewer
 
 	before_action :find_application, except: :list
 
@@ -43,14 +43,14 @@ class JobApplicationsController < ApplicationController
 	def show
 	end
 
-	def list
+  def list
     raise 'Unsupported request' if not request.xhr?
     @job_applications = []
     @job_applications = display_job_applications(params[:type], 5, params[:id])
     render partial: 'jobs/applied_job_list',
           :locals => { job_applications: @job_applications,
                        application_type: params[:type] }
-	end
+  end
 
 	def find_application
 		begin

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -1,7 +1,8 @@
 class JobApplicationsController < ApplicationController
+	
 	include JobApplicationsViewer
 
-	before_action :find_application
+	before_action :find_application, except: :list
 
 	def accept
 		unless @job_application.active?
@@ -40,6 +41,15 @@ class JobApplicationsController < ApplicationController
 	end
 
 	def show
+	end
+
+	def list
+    raise 'Unsupported request' if not request.xhr?
+    @job_applications = []
+    @job_applications = display_job_applications(params[:type], 5, params[:id])
+    render partial: 'jobs/applied_job_list',
+          :locals => { job_applications: @job_applications,
+                       application_type: params[:type] }
 	end
 
 	def find_application

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -1,10 +1,9 @@
 # Job applications controller
 class JobApplicationsController < ApplicationController
   include JobApplicationsViewer
-
+  before_action :user_logged!, except: :list
   before_action :find_application, except: :list
-  before_action :user_logged!
- 
+
   def accept
     if @job_application.active?
       @job_application.accept
@@ -41,8 +40,6 @@ class JobApplicationsController < ApplicationController
     redirect_back_or_default
   end
 
-  private
-
   def list
     raise 'Unsupported request' if not request.xhr?
     @job_applications = []
@@ -52,14 +49,7 @@ class JobApplicationsController < ApplicationController
                        application_type: params[:type] }
   end
 
-	def find_application
-		begin
-			@job_application = JobApplication.find(params[:id])
-		rescue
-			flash[:alert] = "Job Application Entry not found."
-			redirect_back_or_default
-		end
-	end
+  private
 
   def reject_success_response(request)
     if request.xhr?

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -46,7 +46,7 @@ class JobApplicationsController < ApplicationController
   def list
     raise 'Unsupported request' if not request.xhr?
     @job_applications = []
-    @job_applications = display_job_applications(params[:type], 5, params[:id])
+    @job_applications = display_job_applications(params[:type], 5, params[:entity_id])
     render partial: 'jobs/applied_job_list',
           :locals => { job_applications: @job_applications,
                        application_type: params[:type] }

--- a/app/controllers/job_seekers_controller.rb
+++ b/app/controllers/job_seekers_controller.rb
@@ -6,9 +6,11 @@ class JobSeekersController < ApplicationController
 
   def new
     @jobseeker = JobSeeker.new
+    authorize @jobseeker
   end
 
   def create
+    authorize(JobSeeker)
     jobseeker_params = form_params
     dispatch_file    = jobseeker_params.delete 'resume'
 
@@ -41,13 +43,14 @@ class JobSeekersController < ApplicationController
 
   def edit
     @jobseeker = JobSeeker.find(params[:id])
+    authorize @jobseeker
     @current_resume = @jobseeker.resumes[0]
   end
 
   def update
     @jobseeker = JobSeeker.find(params[:id])
-
-    jobseeker_params = handle_user_form_parameters form_params
+    authorize @jobseeker
+    jobseeker_params = handle_user_form_parameters(permitted_attributes(@jobseeker))
     dispatch_file    = jobseeker_params.delete 'resume'
 
     models_saved = @jobseeker.update_attributes(jobseeker_params)
@@ -89,6 +92,7 @@ class JobSeekersController < ApplicationController
   def home
     @jobseeker = JobSeeker.find(params[:id])
     @recent_jobs_type = 'recent-jobs'
+    authorize @jobseeker
     @newjobs = Job.new_jobs(@jobseeker.last_sign_in_at).paginate(:page => params[:page], :per_page => 5)
     @js_last_sign_in = @jobseeker.last_sign_in_at
     @application_type = params[:application_type] || 'my-applied'
@@ -96,10 +100,12 @@ class JobSeekersController < ApplicationController
 
   def index
     @jobseeker = JobSeeker.all
+    authorize @jobseeker
   end
 
   def show
     @jobseeker = JobSeeker.find(params[:id])
+    authorize @jobseeker
     @application_type = params[:application_type] || 'js-applied'
   end
 
@@ -136,9 +142,10 @@ class JobSeekersController < ApplicationController
     redirect_to root_path
   end
 
+ 
   private
-   def form_params
-     params.require(:job_seeker).permit(:first_name,
+    def form_params
+      params.require(:job_seeker).permit(:first_name,
             :last_name, :email, :phone,
             :password,
             :password_confirmation,
@@ -147,5 +154,5 @@ class JobSeekersController < ApplicationController
             :consent,
             :job_seeker_status_id,
             address_attributes: [:id, :street, :city, :zipcode, :state])
-   end
+    end
 end

--- a/app/controllers/job_seekers_controller.rb
+++ b/app/controllers/job_seekers_controller.rb
@@ -79,7 +79,7 @@ class JobSeekersController < ApplicationController
     if models_saved
       sign_in :user, @jobseeker.user, bypass: true if pets_user == @jobseeker
       flash[:notice] = "Jobseeker was updated successfully."
-      redirect_to @jobseeker and return if pets_user == @jobseeker.case_manager
+      redirect_to @jobseeker and return if (pets_user == @jobseeker.case_manager) || (pets_user == @jobseeker.job_developer) 
       redirect_to root_path
     else
       @resume = resume

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -116,7 +116,7 @@ class JobsController < ApplicationController
     @application_type = params[:application_type] || 'job-applied'
 
     @applications = []
-    @applications = display_job_applications @application_type, 5, nil, @job.id
+    @applications = display_job_applications @application_type, 5, @job.id
 
     render partial: 'job_applications'
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -47,7 +47,8 @@ class ApplicationPolicy
     attr_reader :user, :scope
 
     def initialize(user, scope)
-      @user = user
+      @user = nil
+      @user = user.pets_user unless user.nil?
       @scope = scope
     end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -47,8 +47,7 @@ class ApplicationPolicy
     attr_reader :user, :scope
 
     def initialize(user, scope)
-      @user = nil
-      @user = user.pets_user unless user.nil?
+      @user = user
       @scope = scope
     end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -35,8 +35,8 @@ class ApplicationPolicy
     false
   end
 
-  def permit?
-    (record.persisted? && user == record) || (record.new_record? && user.nil?)
+  def allow?
+    true
   end
 
   def scope

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -35,6 +35,10 @@ class ApplicationPolicy
     false
   end
 
+  def permit?
+    (record.persisted? && user == record) || (record.new_record? && user.nil?)
+  end
+
   def scope
     Pundit.policy_scope!(user, record.class)
   end

--- a/app/policies/company_person_policy.rb
+++ b/app/policies/company_person_policy.rb
@@ -1,0 +1,2 @@
+class CompanyPersonPolicy < ApplicationPolicy
+end

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -65,7 +65,7 @@ class JobSeekerPolicy < ApplicationPolicy
         :job_seeker_status_id,
         address_attributes: [:id, :street, :city, :zipcode, :state]
       ]
-    elsif user == record.case_manager
+    elsif (user == record.case_manager) || (user == record.job_developer)
       [ :first_name,
         :last_name, 
         :email, 

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -2,7 +2,8 @@ class JobSeekerPolicy < ApplicationPolicy
   def update?
     # account owner
     # job seeker's case manager
-    user == record || user == record.case_manager 
+    # job seeker's job developer
+    user == record || user == record.case_manager || user == record.job_developer
   end
 
   def edit?
@@ -44,6 +45,10 @@ class JobSeekerPolicy < ApplicationPolicy
 
   def preview_info?
     user == record.job_developer
+  end
+
+  def allow?
+    user.nil? || user == record
   end
 
   def permitted_attributes

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -1,0 +1,71 @@
+class JobSeekerPolicy < ApplicationPolicy
+  def update?
+    # account owner
+    # job seeker's case manager
+    user == record || user == record.case_manager
+  end
+
+  def edit?
+    update?
+  end
+
+  def home?
+    # account owner
+    user == record
+  end
+
+  def index?
+    # all agency people
+    user.is_a?(AgencyPerson)
+  end
+
+  def show?
+    # account's owner
+    # all agency people
+    user == record || user.is_a?(AgencyPerson)
+  end
+
+  def destroy?
+    # account's owner
+    # agency admin
+    user == record || user.is_a?(AgencyPerson)
+  end
+
+  def create?
+    # unlogged in user
+    # agency person
+    user.nil? || user.is_a?(AgencyPerson)
+  end
+
+  def new?
+    create?
+  end
+
+  def permitted_attributes
+    if user == record
+      [ :first_name,
+        :last_name, 
+        :email, 
+        :phone,
+        :password,
+        :password_confirmation,
+        :year_of_birth,
+        :resume,
+        :consent,
+        :job_seeker_status_id,
+        address_attributes: [:id, :street, :city, :zipcode, :state]
+      ]
+    elsif user == record.case_manager
+      [ :first_name,
+        :last_name, 
+        :email, 
+        :phone,
+        :resume,
+        :consent,
+        :job_seeker_status_id,
+        address_attributes: [:id, :street, :city, :zipcode, :state]
+      ]
+    end
+  end
+
+end

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -22,7 +22,8 @@ class JobSeekerPolicy < ApplicationPolicy
   def show?
     # account's owner
     # all agency people
-    user == record || user.is_a?(AgencyPerson)
+    # all company people
+    user == record || user.is_a?(AgencyPerson) || user.is_a?(CompanyPerson)
   end
 
   def destroy?
@@ -41,8 +42,12 @@ class JobSeekerPolicy < ApplicationPolicy
     create?
   end
 
+  def preview_info?
+    user == record.job_developer
+  end
+
   def permitted_attributes
-    if user == record
+    if user == record 
       [ :first_name,
         :last_name, 
         :email, 

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -28,8 +28,7 @@ class JobSeekerPolicy < ApplicationPolicy
 
   def destroy?
     # account's owner
-    # agency admin
-    user == record || user.is_a?(AgencyPerson)
+    user == record
   end
 
   def create?

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -2,7 +2,7 @@ class JobSeekerPolicy < ApplicationPolicy
   def update?
     # account owner
     # job seeker's case manager
-    user == record || user == record.case_manager
+    user == record || user == record.case_manager 
   end
 
   def edit?
@@ -28,7 +28,8 @@ class JobSeekerPolicy < ApplicationPolicy
 
   def destroy?
     # account's owner
-    user == record
+    # agency admin
+    user == record || user.is_agency_admin?(user.try(:agency))
   end
 
   def create?

--- a/app/views/job_seekers/_form.html.haml
+++ b/app/views/job_seekers/_form.html.haml
@@ -8,7 +8,7 @@
   = render partial: 'users/subform',
       locals: {new_form: (new_form if defined? new_form)}
 
-  - if policy(js.object).permit?
+  - if policy(js.object).allow?
     .form-group
       =js.label :year_of_birth, 'Year Of Birth', class:'control-label col-sm-2'
       .col-sm-6

--- a/app/views/job_seekers/_form.html.haml
+++ b/app/views/job_seekers/_form.html.haml
@@ -3,20 +3,23 @@
     = render 'shared/error_messages', object: @jobseeker
     %br
   .clearfix
+  
   - @user_form = js
   = render partial: 'users/subform',
       locals: {new_form: (new_form if defined? new_form)}
-  .form-group
-    =js.label :year_of_birth, 'Year Of Birth', class:'control-label col-sm-2'
-    .col-sm-6
-      - if @jobseeker.year_of_birth
-        - start_year = Date.parse("#{@jobseeker.year_of_birth}0101").year
-      - else
-        - start_year = Date.today.year - 16
 
-      = select_year(start_year, field_name: :year_of_birth,
-                    start_year: start_year, end_year: start_year - 60,
-                    prefix: 'job_seeker')
+  - if policy(js.object).permit?
+    .form-group
+      =js.label :year_of_birth, 'Year Of Birth', class:'control-label col-sm-2'
+      .col-sm-6
+        - if @jobseeker.year_of_birth
+          - start_year = Date.parse("#{@jobseeker.year_of_birth}0101").year
+        - else
+          - start_year = Date.today.year - 16
+
+        = select_year(start_year, field_name: :year_of_birth,
+                      start_year: start_year, end_year: start_year - 60,
+                      prefix: 'job_seeker')
   .form-group
     =js.label :status_id, 'Status', class: 'control-label col-sm-2'
     .col-sm-6

--- a/app/views/job_seekers/home.html.haml
+++ b/app/views/job_seekers/home.html.haml
@@ -14,9 +14,8 @@
     = render partial: 'info', locals: {job_seeker: @jobseeker}
 
 %h3 Your Applications
-.pagination-div{id: "applications-#{@application_type}",
-                data: {url: applied_jobs_job_seeker_path(@jobseeker,
-                                                         @application_type)}}
+.pagination-div{ id: "applications-#{@application_type}",
+                 data: { url: list_applications_path(@application_type, @jobseeker) } }
 
 %h3
   Job Opportunities - New

--- a/app/views/job_seekers/show.html.haml
+++ b/app/views/job_seekers/show.html.haml
@@ -15,13 +15,13 @@
   .pagination-div{id: "applications-#{@application_type}",
                   data: {url: applied_jobs_job_seeker_path(@jobseeker,
                                                          @application_type)}}
-- if pets_user.is_agency_admin?(current_agency) || pets_user == @jobseeker.case_manager
+- if policy(@jobseeker).edit?
   .clearfix
   %br
   .col-sm-2
     = button_to 'Edit Job Seeker', edit_job_seeker_path(@jobseeker),
         method: :get, class: 'btn btn-primary'
-- if pets_user.is_agency_admin? current_agency
+- if policy(@jobseeker).destroy?
   .com-sm-2.col-sm-offset-4
     = button_to 'Delete Job Seeker', job_seeker_path(@jobseeker),
         method: :delete,

--- a/app/views/job_seekers/show.html.haml
+++ b/app/views/job_seekers/show.html.haml
@@ -8,7 +8,7 @@
 .col-sm-9
   = render partial: 'info', locals: {job_seeker: @jobseeker}
 
-- if pets_user == @jobseeker || pets_user.is_a?(AgencyPerson)
+- if policy(@jobseeker).show?
   .col-sm-12
     %h3
       Job Applications for

--- a/app/views/job_seekers/show.html.haml
+++ b/app/views/job_seekers/show.html.haml
@@ -8,13 +8,13 @@
 .col-sm-9
   = render partial: 'info', locals: {job_seeker: @jobseeker}
 
-.col-sm-12
-  %h3
-    Job Applications for
-    = "#{@jobseeker.full_name(last_name_first: false)}"
-  .pagination-div{id: "applications-#{@application_type}",
-                  data: {url: applied_jobs_job_seeker_path(@jobseeker,
-                                                         @application_type)}}
+- if pets_user == @jobseeker || pets_user.is_a?(AgencyPerson)
+  .col-sm-12
+    %h3
+      Job Applications for
+      = "#{@jobseeker.full_name(last_name_first: false)}"
+    .pagination-div{ id: "applications-#{@application_type}",
+                     data: { url: list_applications_path(@application_type, @jobseeker) }}
 - if policy(@jobseeker).edit?
   .clearfix
   %br

--- a/app/views/jobs/_applied_job_list.html.haml
+++ b/app/views/jobs/_applied_job_list.html.haml
@@ -42,6 +42,6 @@
                   = job_application.status_name
 
   = will_paginate job_applications, param_name: 'applications_page',
-                               params: {controller: 'job_seekers',
-                                        action: 'applied_jobs',
-                                        application_type: application_type}
+                               params: {controller: 'job_applications',
+                                        action: 'list',
+                                        type: application_type}

--- a/app/views/users/_subform.html.haml
+++ b/app/views/users/_subform.html.haml
@@ -1,38 +1,38 @@
 .form-group
-	=@user_form.label :first_name, 'First Name', class:'control-label col-sm-2'
-	.col-sm-6
-		=@user_form.text_field :first_name, size: 30, class:'form-control'
+  =@user_form.label :first_name, 'First Name', class:'control-label col-sm-2'
+  .col-sm-6
+    =@user_form.text_field :first_name, size: 30, class:'form-control'
 .form-group
-	=@user_form.label :last_name, 'Last Name', class:'control-label col-sm-2'
-	.col-sm-6
-		=@user_form.text_field :last_name, size: 30, class:'form-control'
+  =@user_form.label :last_name, 'Last Name', class:'control-label col-sm-2'
+  .col-sm-6
+    =@user_form.text_field :last_name, size: 30, class:'form-control'
 
 .form-group
-	=@user_form.label :email, 'Email', class:'control-label col-sm-2'
-	.col-sm-6
-		=@user_form.text_field :email, size: 30, class:'form-control'
+  =@user_form.label :email, 'Email', class:'control-label col-sm-2'
+  .col-sm-6
+    =@user_form.text_field :email, size: 30, class:'form-control'
 .form-group
-	=@user_form.label :phone, 'Phone', class:'control-label col-sm-2'
-	.col-sm-6
-		=@user_form.text_field :phone, size: 30, class:'form-control',
-		placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
+  =@user_form.label :phone, 'Phone', class:'control-label col-sm-2'
+  .col-sm-6
+    =@user_form.text_field :phone, size: 30, class:'form-control',
+    placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
 - if policy(@user_form.object).permit?	
-	.form-group
+  .form-group
 
-		- if defined? new_form and new_form
-			- pw_placeholder = ''
-		- else
-			- pw_placeholder = "leave blank if you don't want to change password"
+    - if defined? new_form and new_form
+      - pw_placeholder = ''
+    - else
+      - pw_placeholder = "leave blank if you don't want to change password"
 
-		=@user_form.label :password, 'Password', class:'control-label col-sm-2'
-		.col-sm-6
-			=@user_form.password_field :password, size: 30, class:'form-control',
-							placeholder: pw_placeholder
-	.form-group
-		=@user_form.label :password_confirmation, 'Password Confirmation',
-									class:'control-label col-sm-2'
-		.col-sm-6
-			=@user_form.password_field :password_confirmation, size: 30,
-									class:'form-control',
-									placeholder: pw_placeholder
+    =@user_form.label :password, 'Password', class:'control-label col-sm-2'
+    .col-sm-6
+      =@user_form.password_field :password, size: 30, class:'form-control',
+                  placeholder: pw_placeholder
+  .form-group
+    =@user_form.label :password_confirmation, 'Password Confirmation',
+                class:'control-label col-sm-2'
+    .col-sm-6
+      =@user_form.password_field :password_confirmation, size: 30,
+                  class:'form-control',
+                  placeholder: pw_placeholder

--- a/app/views/users/_subform.html.haml
+++ b/app/views/users/_subform.html.haml
@@ -17,21 +17,22 @@
 		=@user_form.text_field :phone, size: 30, class:'form-control',
 		placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
-.form-group
+- if policy(@user_form.object).permit?	
+	.form-group
 
-	- if defined? new_form and new_form
-		- pw_placeholder = ''
-	- else
-		- pw_placeholder = "leave blank if you don't want to change password"
+		- if defined? new_form and new_form
+			- pw_placeholder = ''
+		- else
+			- pw_placeholder = "leave blank if you don't want to change password"
 
-	=@user_form.label :password, 'Password', class:'control-label col-sm-2'
-	.col-sm-6
-		=@user_form.password_field :password, size: 30, class:'form-control',
-						placeholder: pw_placeholder
-.form-group
-	=@user_form.label :password_confirmation, 'Password Confirmation',
-								class:'control-label col-sm-2'
-	.col-sm-6
-		=@user_form.password_field :password_confirmation, size: 30,
-								class:'form-control',
-								placeholder: pw_placeholder
+		=@user_form.label :password, 'Password', class:'control-label col-sm-2'
+		.col-sm-6
+			=@user_form.password_field :password, size: 30, class:'form-control',
+							placeholder: pw_placeholder
+	.form-group
+		=@user_form.label :password_confirmation, 'Password Confirmation',
+									class:'control-label col-sm-2'
+		.col-sm-6
+			=@user_form.password_field :password_confirmation, size: 30,
+									class:'form-control',
+									placeholder: pw_placeholder

--- a/app/views/users/_subform.html.haml
+++ b/app/views/users/_subform.html.haml
@@ -17,7 +17,7 @@
     =@user_form.text_field :phone, size: 30, class:'form-control',
     placeholder: 'Eg. 1-369-374-5803 x9579 (\'1-\' prefix and extension optional)'
 
-- if policy(@user_form.object).permit?	
+- if policy(@user_form.object).allow?	
   .form-group
 
     - if defined? new_form and new_form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,7 @@ Rails.application.routes.draw do
                                              as: :reject_application
   get 'job_applications/:id'             => 'job_applications#show',
                                              as: :application
-  get 'job_applications/:type/:id'       => 'job_applications#list', 
+  get 'job_applications/:type/:entity_id'=> 'job_applications#list', 
                                              as: :list_applications
   # --------------------------------------------------------------------------
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,8 @@ Rails.application.routes.draw do
                                              as: :reject_application
   get 'job_applications/:id'             => 'job_applications#show',
                                              as: :application
+  get 'job_applications/:type/:id'       => 'job_applications#list', 
+                                             as: :list_applications
   # --------------------------------------------------------------------------
   
   # ---------------------------- Job Seekers ---------------------------------
@@ -154,8 +156,6 @@ Rails.application.routes.draw do
      get 'match_jobs', on: :member, as: :match_jobs
   end
 
-  get 'job_seekers/:id/applied_jobs/:application_type' =>
-                'job_seekers#applied_jobs', as: :applied_jobs_job_seeker
   get 'job_seekers/:id/preview_info' => 'job_seekers#preview_info'
   # --------------------------------------------------------------------------
 

--- a/features/agency_person.feature
+++ b/features/agency_person.feature
@@ -179,6 +179,9 @@ Given the following agency relations exist:
     Then I click the first "Jones, Mary" link
     Then I click "Edit Job Seeker" button
     And I should see "Edit JobSeeker Registration"
+    And I should not see "Password"
+    And I should not see "Password Confirmation"
+    And I should not see "Year of Birth"
     Then I fill in "First Name" with "Samantha"
     Then I click "Update Job seeker" button
     And I should see "Jobseeker was updated successfully."
@@ -190,7 +193,7 @@ Given the following agency relations exist:
     Given I am on the home page
     And I login as "mark@metplus.org" with password "qwerty123"
     And I wait 1 second
-    Then I click the first "Seeker, Tom" link 
+    Then I click the first "Seeker, John" link 
     And I should not see "Edit Job Seeker"
     
     

--- a/features/step_definitions/job_applications_steps.rb
+++ b/features/step_definitions/job_applications_steps.rb
@@ -8,8 +8,7 @@ And(/^I click "([^"]*)" link to job show page$/) do |job_title|
   find("#applications-job_seeker a[href='/jobs/#{job.id}']").click
 end
 
-And(/^I\sclick\s"([^"]*)"\slink\sto\s"([^"]*)'s"\sjob\sapplication\s
-  show\spage$/x) do |email, js_name|
+And(/^I click "([^"]*)" link to "([^"]*)'s" job application show page$/) do |email, js_name|
   job_seeker = User.find_by_email(email).actable
   @job_app = JobApplication.find_by(job_seeker: job_seeker)
   find("a[href='/job_applications/#{@job_app.id}']").click
@@ -97,8 +96,7 @@ And(/^I should see "([^"]*)" job changes to status filled/) do |job_title|
   find('#job-status') { expect(page).to have_content('filled') }
 end
 
-And(/^I\sshould\ssee\smy\sapplication\sfor\s"([^"]*)"\sshow\sstatus\s
-  "([^"]*)"$/x) do |job_title, status|
+And(/^I should see my application for "([^"]*)" show status "([^"]*)"$/) do |job_title, status|
   job = Job.find_by(title: "#{job_title}")
   job_app = JobApplication.find_by(job: job)
   expect(page.find("#applications-#{job_app.id}")).to have_content("#{status}")

--- a/features/step_definitions/job_applications_steps.rb
+++ b/features/step_definitions/job_applications_steps.rb
@@ -1,113 +1,123 @@
 And(/^I click "([^"]*)" link to job applications index page$/) do |job_title|
-	job = Job.find_by(title: "#{job_title}")
-	find("a[href='/jobs/#{job.id}/applications']").click
+  job = Job.find_by(title: "#{job_title}")
+  find("a[href='/jobs/#{job.id}/applications']").click
 end
 
 And(/^I click "([^"]*)" link to job show page$/) do |job_title|
-	job = Job.find_by(title: "#{job_title}")
-	find("#applications-job_seeker a[href='/jobs/#{job.id}']").click
+  job = Job.find_by(title: "#{job_title}")
+  find("#applications-job_seeker a[href='/jobs/#{job.id}']").click
 end
 
-And(/^I click "([^"]*)" link to "([^"]*)'s" job application show page$/) do |email, js_name|
-	job_seeker = User.find_by_email(email).actable
-	@job_app = JobApplication.find_by(job_seeker: job_seeker)
-	find("a[href='/job_applications/#{@job_app.id}']").click
+And(/^I\sclick\s"([^"]*)"\slink\sto\s"([^"]*)'s"\sjob\sapplication\s
+  show\spage$/x) do |email, js_name|
+  job_seeker = User.find_by_email(email).actable
+  @job_app = JobApplication.find_by(job_seeker: job_seeker)
+  find("a[href='/job_applications/#{@job_app.id}']").click
 end
 
 And(/^I accept "([^"]*)" application$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	@job_app = JobApplication.find_by(job_seeker: job_seeker)
-	find("#applications-#{@job_app.id} #accept_link").click
+  job_seeker = User.find_by_email(email).actable
+  @job_app = JobApplication.find_by(job_seeker: job_seeker)
+  find("#applications-#{@job_app.id} #accept_link").click
 end
 
 And(/^I reject "([^"]*)" application$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	@job_app = JobApplication.find_by(job_seeker: job_seeker)
-	find("#applications-#{@job_app.id} #reject_link").click
+  job_seeker = User.find_by_email(email).actable
+  @job_app = JobApplication.find_by(job_seeker: job_seeker)
+  find("#applications-#{@job_app.id} #reject_link").click
 end
 
 And(/^I should see an "([^"]*)" confirmation$/) do |action|
-	expect(page).to have_content("Are you sure you want
- 		         to #{action} the following application:
- 		         		 Applicant's Name: #{@job_app.job_seeker.full_name(last_name_first: false)}
-                 Job Title:  #{@job_app.job.title}
-                 Company Job ID: #{@job_app.job.company_job_id}")
+  expect(page).to have_content("Are you sure you want
+    to #{action} the following application:
+    Applicant's Name: #{@job_app.job_seeker.full_name(last_name_first: false)}
+    Job Title:  #{@job_app.job.title}
+    Company Job ID: #{@job_app.job.company_job_id}")
 end
 
 And(/^I click the "([^"]*)" confirmation$/) do |action|
-	find("a[href='/job_applications/#{@job_app.id}/#{action.downcase}']").click
+  find("a[href='/job_applications/#{@job_app.id}/#{action.downcase}']").click
 end
 
 And(/^I should see "([^"]*)" active applications for the job$/) do |count|
-	@app_ids = JobApplication.select(:id).where(status: 'active')
-	expect(@app_ids.count).to eq count.to_i
+  @app_ids = JobApplication.select(:id).where(status: 'active')
+  expect(@app_ids.count).to eq count.to_i
 end
 
 And(/^I should see "([^"]*)" application changes to accepted$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	@app_accepted = JobApplication.find_by(job_seeker: job_seeker)
-	within("#applications-#{@app_accepted.id}") { expect(page).to have_content("accepted") }
+  job_seeker = User.find_by_email(email).actable
+  @app_accepted = JobApplication.find_by(job_seeker: job_seeker)
+  within("#applications-#{@app_accepted.id}") do
+    expect(page).to have_content('accepted')
+  end
 end
 
 And(/^I should see "([^"]*)" application changes to not_accepted$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	@app_rejected = JobApplication.find_by(job_seeker: job_seeker)
-	within("#applications-#{@app_rejected.id}") { expect(page).to have_content("not_accepted") }
+  job_seeker = User.find_by_email(email).actable
+  @app_rejected = JobApplication.find_by(job_seeker: job_seeker)
+  within("#applications-#{@app_rejected.id}") do
+    expect(page).to have_content('not_accepted')
+  end
 end
 
-# this step can only be used in a scenario that includes steps line:35 and line:42
-# which define @app_ids, @app_accepted
+# this step can only be used in a scenario that includes 
+# steps line:35 and line:42 which define @app_ids, @app_accepted
 And(/^other applications change to not accepted$/) do
-	@app_ids.each do |app|
-		expect(page.find("#applications-#{app.id}")).
-				to have_content("not_accepted") unless app.id == @app_accepted.id
-	end
+  @app_ids.each do |app|
+    expect(page.find("#applications-#{app.id}")).
+    to have_content('not_accepted') unless app.id == @app_accepted.id
+  end
 end
 
 Then(/^I should( not)? see(?: an)? "([^"]*)" link$/) do |not_see, action|
-	if not_see
-		expect(page).not_to have_css("#{action.downcase}_link", text: "#{action}")
-	else
-		expect(page).to have_css("#{action.downcase}_link", text: "#{action}")
-	end
+  if not_see
+    expect(page).not_to have_css("#{action.downcase}_link", text: "#{action}")
+  else
+    expect(page).to have_css("#{action.downcase}_link", text: "#{action}")
+  end
 end
 
 And(/^I should see "([^"]*)" application is listed first$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	job_app = JobApplication.find_by(job_seeker: job_seeker)
-	within(".pagination-div > table > tbody > tr:first-child") { expect(page).to have_content("#{job_seeker.first_name}") }
+  job_seeker = User.find_by_email(email).actable
+  job_app = JobApplication.find_by(job_seeker: job_seeker)
+  within('.pagination-div > table > tbody > tr:first-child') do
+    expect(page).to have_content("#{job_seeker.first_name}")
+  end
 end
 
 And(/^I should see "([^"]*)" application is listed last$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	job_app = JobApplication.find_by(job_seeker: job_seeker)
-	within(".pagination-div > table > tbody > tr:last-child") { expect(page).to have_content("#{job_seeker.first_name}") }
+  job_seeker = User.find_by_email(email).actable
+  job_app = JobApplication.find_by(job_seeker: job_seeker)
+  within('.pagination-div > table > tbody > tr:last-child') do
+    expect(page).to have_content("#{job_seeker.first_name}")
+  end
 end
 
 And(/^I should see "([^"]*)" job changes to status filled/) do |job_title|
-	find("#job-status") { expect(page).to have_content("filled") }
+  find('#job-status') { expect(page).to have_content('filled') }
 end
 
-And(/^I should see my application for "([^"]*)" show status "([^"]*)"$/) do |job_title, status|
-	job = Job.find_by(title: "#{job_title}")
-	job_app = JobApplication.find_by(job: job)
-	expect(page.find("#applications-#{job_app.id}")).to have_content("#{status}")
+And(/^I\sshould\ssee\smy\sapplication\sfor\s"([^"]*)"\sshow\sstatus\s
+  "([^"]*)"$/x) do |job_title, status|
+  job = Job.find_by(title: "#{job_title}")
+  job_app = JobApplication.find_by(job: job)
+  expect(page.find("#applications-#{job_app.id}")).to have_content("#{status}")
 end
 
 And(/^I am returned to "([^"]*)" job application index page$/) do |job_title|
-	expect(page.find("#job-title")).to have_content("#{job_title}")
+  expect(page.find('#job-title')).to have_content("#{job_title}")
 end
 
 And(/^I should see "(?:[^"]*)" show status "([^"]*)"$/) do |status|
-	expect(page.find("#job-status")).to have_content("#{status}")
+  expect(page.find('#job-status')).to have_content("#{status}")
 end
 
 And(/^I return to my "([^"]*)" home page$/) do |email|
-	job_seeker = User.find_by_email(email).actable
-	role = job_seeker.class.to_s.underscore
-	visit "/#{role}s/#{job_seeker.id}/home"
+  job_seeker = User.find_by_email(email).actable
+  role = job_seeker.class.to_s.underscore
+  visit "/#{role}s/#{job_seeker.id}/home"
 end
 
 And(/^I input "([^"]*)" as the reason for rejection$/) do |reason|
-	step %{I fill in "reason_text" with "#{reason}"}
+  step %{I fill in "reason_text" with "#{reason}"}
 end

--- a/features/step_definitions/job_applications_steps.rb
+++ b/features/step_definitions/job_applications_steps.rb
@@ -5,7 +5,7 @@ end
 
 And(/^I click "([^"]*)" link to job show page$/) do |job_title|
 	job = Job.find_by(title: "#{job_title}")
-	find("#applications-my-applied a[href='/jobs/#{job.id}']").click
+	find("#applications-job_seeker a[href='/jobs/#{job.id}']").click
 end
 
 And(/^I click "([^"]*)" link to "([^"]*)'s" job application show page$/) do |email, js_name|

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe JobApplicationsController, type: :controller do
 	    	expect(assigns(:job_application)).to eq invalid_application
 	    end
 			it 'show a flash[:alert]' do
-				expect(flash[:alert]).to eq "Invalid action on inactive job application."
+				expect(flash[:alert]).to eq 'Invalid action on inactive job application.'
 			end
 			it 'redirect to the specific job application index page' do
 				expect(response).to redirect_to(applications_job_url(invalid_application.job))
@@ -34,7 +34,7 @@ RSpec.describe JobApplicationsController, type: :controller do
 				patch :accept, id: valid_application
 			end
 			it 'show a flash[:info]' do
-				expect(flash[:info]).to eq "Job application accepted."
+				expect(flash[:info]).to eq 'Job application accepted.'
 			end
 			it 'redirect to the specific job application index page' do
 				expect(response).to redirect_to(applications_job_url(valid_application.job))
@@ -50,7 +50,7 @@ RSpec.describe JobApplicationsController, type: :controller do
 				patch :reject, id: valid_application
 			end
 			it 'show a flash[:info]' do
-				expect(flash[:notice]).to eq "Job application rejected."
+				expect(flash[:notice]).to eq 'Job application rejected.'
 			end
 			it 'redirect to the specific job application index page' do
 				expect(response).to redirect_to(applications_job_url(valid_application.job))
@@ -62,7 +62,7 @@ RSpec.describe JobApplicationsController, type: :controller do
 		context 'Invalid Request' do
 			it 'shows a flash[:alert]' do
 				get :show, id: anything
-				expect(flash[:alert]).to eq "Job Application Entry not found."
+				expect(flash[:alert]).to eq 'Job Application Entry not found.'
 			end
 		end
 	end
@@ -72,20 +72,28 @@ RSpec.describe JobApplicationsController, type: :controller do
     let(:job1) { FactoryGirl.create(:job) }
     let(:job2) { FactoryGirl.create(:job) }
     let(:job3) { FactoryGirl.create(:job) }
-    let(:app1) { FactoryGirl.create(:job_application,
-                               job: job1, job_seeker: job_seeker)}
-    let(:app2) { FactoryGirl.create(:job_application,
-                               job: job2, job_seeker: job_seeker)}
-    let(:app3) { FactoryGirl.create(:job_application,
-                               job: job3, job_seeker: job_seeker)}
-    let(:app4) { FactoryGirl.create(:job_application,
+    let(:app1) do 
+      FactoryGirl.create(:job_application,
+                               job: job1, job_seeker: job_seeker) 
+    end
+    let(:app2) do 
+      FactoryGirl.create(:job_application,
+                               job: job2, job_seeker: job_seeker) 
+    end
+    let(:app3) do 
+      FactoryGirl.create(:job_application,
+                               job: job3, job_seeker: job_seeker) 
+    end
+    let(:app4) do 
+      FactoryGirl.create(:job_application,
                                job: job3,
-                               job_seeker: FactoryGirl.create(:job_seeker)) }
+                               job_seeker: FactoryGirl.create(:job_seeker)) 
+    end
 
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create
-      xhr :get, :list, type: "job_seeker", entity_id: job_seeker
+      xhr :get, :list, type: 'job_seeker', entity_id: job_seeker
     end
 
     it 'assigns jobs for view' do

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -3,69 +3,79 @@ include ServiceStubHelpers::Cruncher
 
 RSpec.describe JobApplicationsController, type: :controller do
 
-	describe 'PATCH accept' do
-		let(:job) { FactoryGirl.create(:job) }
-		let(:job_seeker) { FactoryGirl.create(:job_seeker) }
-		let(:invalid_application) { FactoryGirl.create(:job_application, job: job, job_seeker: job_seeker, status: 'accepted')}
-		let(:valid_application) { FactoryGirl.create(:job_application, job: job, job_seeker: job_seeker) }
+  describe 'PATCH accept' do
+    let(:job) { FactoryGirl.create(:job) }
+    let(:job_seeker) { FactoryGirl.create(:job_seeker) }
+    let(:invalid_application) do 
+      FactoryGirl.create(:job_application, 
+        job: job, job_seeker: job_seeker, status: 'accepted') 
+    end
+    let(:valid_application) do 
+      FactoryGirl.create(:job_application, 
+        job: job, job_seeker: job_seeker) 
+    end
 
-		context 'Invalid Job Application' do
-			before (:each) do
-				stub_cruncher_authenticate
-      	stub_cruncher_job_create
-				patch :accept, id: invalid_application
-	    end
-	    it 'look for the invalid application' do
-	    	expect(assigns(:job_application)).to eq invalid_application
-	    end
-			it 'show a flash[:alert]' do
-				expect(flash[:alert]).to eq 'Invalid action on inactive job application.'
-			end
-			it 'redirect to the specific job application index page' do
-				expect(response).to redirect_to(applications_job_url(invalid_application.job))
-			end
-		end
+    context 'Invalid Job Application' do
+      before (:each) do
+        stub_cruncher_authenticate
+        stub_cruncher_job_create
+        patch :accept, id: invalid_application
+      end
+      it 'look for the invalid application' do
+        expect(assigns(:job_application)).to eq invalid_application
+      end
+      it 'show a flash[:alert]' do
+        expect(flash[:alert]).
+        to eq 'Invalid action on inactive job application.'
+      end
+      it 'redirect to the specific job application index page' do
+        expect(response).
+        to redirect_to(applications_job_url(invalid_application.job))
+      end
+    end
 
-		context 'Valid Job Application' do
-			before (:each) do
-				stub_cruncher_authenticate
-      	stub_cruncher_job_create
-				expect_any_instance_of(JobApplication).to receive(:accept)
-				patch :accept, id: valid_application
-			end
-			it 'show a flash[:info]' do
-				expect(flash[:info]).to eq 'Job application accepted.'
-			end
-			it 'redirect to the specific job application index page' do
-				expect(response).to redirect_to(applications_job_url(valid_application.job))
-			end
+    context 'Valid Job Application' do
+      before (:each) do
+        stub_cruncher_authenticate
+        stub_cruncher_job_create
+        expect_any_instance_of(JobApplication).to receive(:accept)
+        patch :accept, id: valid_application
+      end
+      it 'show a flash[:info]' do
+        expect(flash[:info]).to eq 'Job application accepted.'
+      end
+      it 'redirect to the specific job application index page' do
+        expect(response).
+        to redirect_to(applications_job_url(valid_application.job))
+      end
     end
 
 
-		context 'Valid Job Application Rejected' do
-			before (:each) do
-				stub_cruncher_authenticate
-				stub_cruncher_job_create
-				expect_any_instance_of(JobApplication).to receive(:reject)
-				patch :reject, id: valid_application
-			end
-			it 'show a flash[:info]' do
-				expect(flash[:notice]).to eq 'Job application rejected.'
-			end
-			it 'redirect to the specific job application index page' do
-				expect(response).to redirect_to(applications_job_url(valid_application.job))
-			end
-		end
-	end
+    context 'Valid Job Application Rejected' do
+      before (:each) do
+        stub_cruncher_authenticate
+        stub_cruncher_job_create
+        expect_any_instance_of(JobApplication).to receive(:reject)
+        patch :reject, id: valid_application
+      end
+      it 'show a flash[:info]' do
+        expect(flash[:notice]).to eq 'Job application rejected.'
+      end
+      it 'redirect to the specific job application index page' do
+        expect(response).
+        to redirect_to(applications_job_url(valid_application.job))
+      end
+    end
+  end
 
-	describe 'GET show' do
-		context 'Invalid Request' do
-			it 'shows a flash[:alert]' do
-				get :show, id: anything
-				expect(flash[:alert]).to eq 'Job Application Entry not found.'
-			end
-		end
-	end
+  describe 'GET show' do
+    context 'Invalid Request' do
+      it 'shows a flash[:alert]' do
+        get :show, id: anything
+        expect(flash[:alert]).to eq 'Job Application Entry not found.'
+      end
+    end
+  end
 
   describe 'GET #list' do
     let(:job_seeker) { FactoryGirl.create(:job_seeker) }

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe JobApplicationsController, type: :controller do
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create
-      xhr :get, :list, type: "job_seeker", id: job_seeker
+      xhr :get, :list, type: "job_seeker", entity_id: job_seeker
     end
 
     it 'assigns jobs for view' do

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -66,4 +66,35 @@ RSpec.describe JobApplicationsController, type: :controller do
 			end
 		end
 	end
+
+  describe 'GET #list' do
+    let(:job_seeker) { FactoryGirl.create(:job_seeker) }
+    let(:job1) { FactoryGirl.create(:job) }
+    let(:job2) { FactoryGirl.create(:job) }
+    let(:job3) { FactoryGirl.create(:job) }
+    let(:app1) { FactoryGirl.create(:job_application,
+                               job: job1, job_seeker: job_seeker)}
+    let(:app2) { FactoryGirl.create(:job_application,
+                               job: job2, job_seeker: job_seeker)}
+    let(:app3) { FactoryGirl.create(:job_application,
+                               job: job3, job_seeker: job_seeker)}
+    let(:app4) { FactoryGirl.create(:job_application,
+                               job: job3,
+                               job_seeker: FactoryGirl.create(:job_seeker)) }
+
+    before(:each) do
+      stub_cruncher_authenticate
+      stub_cruncher_job_create
+      xhr :get, :list, type: "job_seeker", id: job_seeker
+    end
+
+    it 'assigns jobs for view' do
+      expect(assigns(:job_applications)).to include(app1, app2, app3)
+      expect(assigns(:job_applications)).not_to include(app4)
+    end
+
+    it 'renders partial for applications' do
+      expect(response).to render_template(partial: 'jobs/_applied_job_list')
+    end
+  end
 end

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe JobApplicationsController, type: :controller do
           end
           it 'show a flash[:alert]' do
             expect(flash[:alert]).to eq 'Invalid action on'\
-  							' inactive job application.'
+                ' inactive job application.'
           end
           it 'redirect to the specific job application index page' do
             expect(response).to redirect_to(applications_job_url(
@@ -358,6 +358,7 @@ RSpec.describe JobApplicationsController, type: :controller do
       end
     end
   end
+
   describe 'GET #list' do
     let(:job_seeker) { FactoryGirl.create(:job_seeker) }
     let(:job1) { FactoryGirl.create(:job) }
@@ -378,7 +379,8 @@ RSpec.describe JobApplicationsController, type: :controller do
     let(:app4) do 
       FactoryGirl.create(:job_application,
                                job: job3,
-                               job_seeker: FactoryGirl.create(:job_seeker)) 
+                               job_seeker: FactoryGirl.create(:job_seeker))
+    end
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -1,8 +1,36 @@
 require 'rails_helper'
 include ServiceStubHelpers::Cruncher
 
+RSpec.shared_examples 'unauthorized' do
+  before :each do
+    warden.set_user user
+  end
+  it 'redirects to the home page' do
+    expect(response).to redirect_to(root_path)
+  end
+  it 'sets the flash' do
+    expect(flash[:alert]).to eq 'You are not authorized to to perform this action.'
+  end
+  # it 'sets the flash' do
+  #   expect(flash[:alert]).to eq 'You need to login to perform this action.'
+  # end
+end
+
+RSpec.shared_examples 'authorized' do
+  before :each do
+    warden.set_user user
+  end
+  it 'returns http success' do
+    expect(response).to have_http_status(:success)
+  end
+end
+
 RSpec.describe JobSeekersController, type: :controller do
   describe 'GET #new' do
+    context 'visitor' do
+      it_behaves_like "authorized" { let(:user) { nil } }
+    end
+
     it 'renders new template' do
       get :new
       expect(response).to render_template 'new'

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -1,24 +1,120 @@
 require 'rails_helper'
 include ServiceStubHelpers::Cruncher
 
-RSpec.shared_examples 'unauthorized' do
-  before :each do
-    warden.set_user user
+module Helpers
+  def assign_role(role)
+    let(:agency) { FactoryGirl.create(:agency) }
+    let(:company) { FactoryGirl.create(:company, agencies: [agency]) }
+    case role
+    when 'job_seeker'
+      let(:person) { FactoryGirl.create(:job_seeker) }
+    when 'owner'
+      let(:person) { owner }
+    when 'owner_job_developer'
+      let(:person) { owner_job_developer }
+    when 'owner_case_manager'
+      let(:person) { owner_case_manager }
+    when 'company_person', 'company_admin', 'company_contact'
+      let(:person) { FactoryGirl.send(:create, role.to_sym, company: company) } 
+    when 'agency_person', 'job_developer', 'case_manager', 'agency_admin'
+      let(:person) { FactoryGirl.send(:create, role.to_sym, agency: agency) }
+    else
+      let(:person) { nil }
+    end
   end
-  it 'redirects to the home page' do
-    expect(response).to redirect_to(root_path)
+
+  def assign_role_action(role, action)
+    let(:agency) { FactoryGirl.create(:agency) }
+    let(:company) { FactoryGirl.create(:company, agencies: [agency]) }
+    let(:status) { FactoryGirl.create(:job_seeker_status) }
+    let(:valid_attribute) do
+      FactoryGirl.attributes_for(:job_seeker).
+      merge(FactoryGirl.attributes_for(:user)).
+      merge(job_seeker_status_id: status.id).
+      merge(address_attributes: FactoryGirl.attributes_for(:address,
+        zipcode: '12346'))
+    end
+    case role
+    when 'owner'
+      let(:person) { owner } 
+    when 'agency_person', 'job_developer', 'case_manager', 'agency_admin'
+      let(:person) { FactoryGirl.send(:create, role.to_sym, agency: agency) }
+    else
+      let(:person) { nil }
+    end
+
+    case action
+    when 'create'
+      let(:message) { "A message with a confirmation and link has been sent to your email address. " +
+                "Please follow the link to activate your account." }
+      let(:request) { post :create, job_seeker: valid_attribute }
+    when 'destroy'
+      let(:message) { "Jobseeker was deleted successfully." }
+      let(:request) { delete :destroy, id: owner }
+    else
+      let(:message) { nil }
+    end
   end
-  it 'sets the flash' do
-    expect(flash[:alert]).to eq 'You are not authorized to to perform this action.'
-  end
-  # it 'sets the flash' do
-  #   expect(flash[:alert]).to eq 'You need to login to perform this action.'
-  # end
 end
 
-RSpec.shared_examples 'authorized' do
+RSpec.configure do |c|
+  c.extend Helpers
+end 
+
+RSpec.shared_examples 'unauthorized action' do |role|
+  assign_role(role)
   before :each do
-    warden.set_user user
+    warden.set_user person
+    request
+  end
+  it 'returns http redirect' do
+    expect(response).to have_http_status(:redirect)
+  end
+  it 'sets flash[:alert] message' do
+    expect(flash[:alert]).to eq('You are not authorized to perform this action.').
+    or eq('You need to login to perform this action.')
+  end
+end
+
+RSpec.shared_examples "unauthorized action (xhr)" do |role|
+  assign_role(role)
+  before :each do
+    warden.set_user person
+    request
+  end
+  it 'returns http unauthorized / forbidden' do
+    expect(response).to have_http_status(:unauthorized).
+    or have_http_status(:forbidden)
+  end
+  it 'returns unauthenticated / unauthorized message' do
+    expect(JSON.parse(response.body, symbolize_names: true)[:message]).
+    to eq('You need to login to perform this action.').
+    or eq('You are not authorized to perform this action.')
+  end
+end
+
+RSpec.shared_examples 'authorized to create / destroy job seeker' do |role, action|
+  assign_role_action(role, action)
+  before :each do
+    warden.set_user person
+    request
+  end
+  it 'sets flash[:notice] message' do
+    expect(flash[:notice]).to eq message
+  end
+  it 'returns redirect status' do
+    expect(response).to have_http_status(:redirect)
+  end
+  it 'redirects to root page' do
+    expect(response).to redirect_to(root_path)
+  end
+end
+
+RSpec.shared_examples 'authorized to retrieve data' do |role|
+  assign_role(role)
+  before :each do
+    warden.set_user person
+    request
   end
   it 'returns http success' do
     expect(response).to have_http_status(:success)
@@ -27,20 +123,40 @@ end
 
 RSpec.describe JobSeekersController, type: :controller do
   describe 'GET #new' do
+    let(:request) { get :new }
     context 'visitor' do
-      it_behaves_like "authorized" { let(:user) { nil } }
+      it_behaves_like 'authorized to retrieve data', 'visitor'
     end
-
+    context 'agency_person' do
+      it_behaves_like "authorized to retrieve data", 'agency_person'
+    end
+    context 'job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_person'
+    end
     it 'renders new template' do
-      get :new
+      request
       expect(response).to render_template 'new'
-    end
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
     end
   end
 
   describe 'POST #create' do
+    let(:request) { post :create, job_seeker: FactoryGirl.attributes_for(:job_seeker) }
+    context 'visitor' do
+      it_behaves_like 'authorized to create / destroy job seeker', 'visitor', 'create'
+    end
+    context 'agency_person' do
+      it_behaves_like 'authorized to create / destroy job seeker', 'agency_person', 'create'
+    end
+    context 'job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_person'
+    end
+    
     context 'valid attributes' do
       before(:each) do
         js_status = FactoryGirl.create(:job_seeker_status)
@@ -51,20 +167,6 @@ RSpec.describe JobSeekersController, type: :controller do
         @js_hash[:address_attributes] = FactoryGirl.attributes_for(:address,
                                           zipcode: '54321')
         post :create, job_seeker: @js_hash
-      end
-
-      it 'sets flash message' do
-        message = 'A message with a confirmation and link has been sent to '\
-                  'your email address. Please follow the link to activate '\
-                  'your account.'
-        expect(flash[:notice]).to eq message
-      end
-
-      it 'returns redirect status' do
-        expect(response).to have_http_status(:redirect)
-      end
-      it 'redirects to root page' do
-        expect(response).to redirect_to(root_path)
       end
       it 'check address' do
         js = User.find_by_email(@js_hash[:email]).pets_user
@@ -146,60 +248,82 @@ RSpec.describe JobSeekersController, type: :controller do
     end
   end
 
-  describe 'PATCH #update' do
-    context ' updated by job seeker ' do
-      let(:jobseeker) { FactoryGirl.create(:job_seeker) }
+  describe 'PATCH #update' do 
+    let(:agency) { FactoryGirl.create(:agency) }
+    let(:owner_job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
+    let(:owner_case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
+    let(:owner) do 
+      js = FactoryGirl.create(:job_seeker, phone: '123-456-7890')
+      js.assign_job_developer(owner_job_developer, agency)
+      js.assign_case_manager(owner_case_manager, agency)
+      js
+    end
+    let(:request) { patch :update, id: owner }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action', 'visitor'
+    end
+    context 'agency_person' do
+      it_behaves_like "unauthorized", 'agency_admin'
+      it_behaves_like "unauthorized", 'job_developer'
+      it_behaves_like "unauthorized", 'case_manager'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_person'
+    end
+    context 'job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'owner' do
       let(:js_status) { FactoryGirl.create(:job_seeker_status) }
-      let(:password) { jobseeker.encrypted_password }
+      let(:password) { owner.encrypted_password }
       before(:each) do
         stub_cruncher_authenticate
         stub_cruncher_file_upload
-
-        sign_in jobseeker
+        sign_in owner
       end
-
       context 'successful initial résumé upload' do
         it 'saves the first resume record' do
           expect do
             patch :update,
-                  id: jobseeker,
+                  id: owner,
                   job_seeker: FactoryGirl.attributes_for(:job_seeker,
                     resume: fixture_file_upload('files/Janitor-Resume.doc'))
-          end
-            .to change(Resume, :count).by(+1)
+          end.to change(Resume, :count).by(+1)
           expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
         end
       end
-
       context 'valid attributes without password change' do
         before(:each) do
           FactoryGirl.create(:resume, 
             file_name: 'Janitor-Resume.doc',
             file: fixture_file_upload('files/Janitor-Resume.doc'),
-            job_seeker: jobseeker)
-          patch :update,
-            id: jobseeker,
+            job_seeker: owner)
+          patch :update, 
+            id: owner,
             job_seeker: FactoryGirl.attributes_for(:job_seeker,
-              year_of_birth: '1980', first_name: 'John',
-              last_name: 'Smith', password: '',
-              password_confirmation: '', phone: '780-890-8976',
-              resume: fixture_file_upload('files/Admin-Assistant-Resume.pdf'))
-              .merge(job_seeker_status_id: js_status.id)
-              .merge(address_attributes: FactoryGirl.attributes_for(:address,
-                zipcode: '12346'))
-          jobseeker.reload
+              year_of_birth: '1980', 
+              first_name: 'John',
+              last_name: 'Smith', 
+              password: '',
+              password_confirmation: '', 
+              phone: '780-890-8976',
+              resume: fixture_file_upload('files/Admin-Assistant-Resume.pdf')).
+            merge(job_seeker_status_id: js_status.id).
+            merge(address_attributes: FactoryGirl.attributes_for(:address,
+              zipcode: '12346'))
+          owner.reload
         end
         it 'sets the valid attributes' do
-          expect(jobseeker.first_name).to eq 'John'
-          expect(jobseeker.last_name).to eq 'Smith'
-          expect(jobseeker.year_of_birth).to eq '1980'
-          expect(jobseeker.status.id).to eq js_status.id
-          expect(jobseeker.address.zipcode).to eq '12346'
-          expect(jobseeker.resumes[0].file_name).
+          expect(owner.first_name).to eq 'John'
+          expect(owner.last_name).to eq 'Smith'
+          expect(owner.year_of_birth).to eq '1980'
+          expect(owner.status.id).to eq js_status.id
+          expect(owner.address.zipcode).to eq '12346'
+          expect(owner.resumes[0].file_name).
           to eq 'Admin-Assistant-Resume.pdf'
         end
         it 'dont change password' do
-          expect(jobseeker.encrypted_password).to eq password
+          expect(owner.encrypted_password).to eq password
         end
         it 'sets flash message' do
           expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
@@ -211,23 +335,21 @@ RSpec.describe JobSeekersController, type: :controller do
           expect(response).to redirect_to(root_path)
         end
       end
-
       context 'unsuccessful résumé upload' do
         render_views
-
         before(:each) do
           FactoryGirl.create(:resume,
             file_name: 'Janitor-Resume.doc',
             file: fixture_file_upload('files/Janitor-Resume.doc'),
-            job_seeker: jobseeker)
+            job_seeker: owner)
           patch :update, 
-                id: jobseeker,
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
                   resume: fixture_file_upload('files/Example Excel File.xls'))
-          jobseeker.reload
+          owner.reload
         end
         it 'does not update existing resume' do
-          expect(jobseeker.resumes[0].file_name).to eq 'Janitor-Resume.doc'
+          expect(owner.resumes[0].file_name).to eq 'Janitor-Resume.doc'
         end
         it 'output file unsupported message' do
           expect(response.body).to have_content('unsupported file type')
@@ -236,13 +358,12 @@ RSpec.describe JobSeekersController, type: :controller do
           expect(response).to render_template('edit')
         end
       end
-
       context 'invalid attributes' do
         before(:each) do
-          jobseeker.assign_attributes(year_of_birth: '198')
-          jobseeker.valid?
+          owner.assign_attributes(year_of_birth: '198')
+          owner.valid?
           patch :update,
-                id: jobseeker,
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
                   year_of_birth: '198',
                   resume: '')
@@ -255,66 +376,118 @@ RSpec.describe JobSeekersController, type: :controller do
         end
       end
     end
-
-    context " updated by job seeker's case manager " do
-      let(:agency) { FactoryGirl.create(:agency) }
-      let(:jobseeker) { FactoryGirl.create(:job_seeker, phone: '123-456-7890') }
-      let(:case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
-      let(:password) { jobseeker.encrypted_password }
+    context " related case manager " do
+      let(:password) { owner.encrypted_password }
       before(:each) do
-        sign_in case_manager
-        jobseeker.assign_case_manager(case_manager, agency)
+        sign_in owner_case_manager
       end
       context 'valid attributes' do
         it 'locates the requested @jobseeker' do
           patch :update,
-                id: case_manager.job_seekers.first,
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker)
-          expect(assigns(:jobseeker)).to eq(jobseeker)
+          expect(assigns(:jobseeker)).to eq(owner)
         end
         it "changes @jobseeker's attribute" do
           patch :update,
-                id: case_manager.job_seekers.first,
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
                   phone: '111-111-1111')
-          jobseeker.reload
-          expect(jobseeker.phone).to eq('111-111-1111')
+          owner.reload
+          expect(owner.phone).to eq('111-111-1111')
         end
         it 'sets flash message and redirects to job seeker show page' do
           patch :update,
-                id: case_manager.job_seekers.first,
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker)
           expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
-          expect(response).to redirect_to jobseeker
+          expect(response).to redirect_to owner
         end
       end
-
       context 'unauthorized attributes' do
         before(:each) do
           patch :update,
-                id: case_manager.job_seekers.first,
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
                   year_of_birth: '1988',
                   password: '123345',
                   password_confirmation: '123345')
-          jobseeker.reload
+          owner.reload
         end
         it "does not change job seeker's attribute" do
-          expect(jobseeker.year_of_birth).to eq('1998')
-          expect(jobseeker.encrypted_password).to eq password
+          expect(owner.year_of_birth).to eq('1998')
+          expect(owner.encrypted_password).to eq password
         end
       end
-
       context 'invalid attributes' do
         before(:each) do
           patch :update,
-                id: case_manager.job_seekers.first, 
+                id: owner, 
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
                   phone: '123')
-          jobseeker.reload
+          owner.reload
         end
         it "does not change job seeker's attribute" do
-          expect(jobseeker.phone).to eq('123-456-7890')
+          expect(owner.phone).to eq('123-456-7890')
+        end
+        it 're-renders the edit template' do
+          expect(response).to render_template('edit')
+        end
+      end
+    end
+    context " related job_developer " do
+      let(:password) { owner.encrypted_password }
+      before(:each) do
+        sign_in owner_job_developer
+      end
+      context 'valid attributes' do
+        it 'locates the requested @jobseeker' do
+          patch :update,
+                id: owner,
+                job_seeker: FactoryGirl.attributes_for(:job_seeker)
+          expect(assigns(:jobseeker)).to eq(owner)
+        end
+        it "changes @jobseeker's attribute" do
+          patch :update,
+                id: owner,
+                job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                  phone: '111-111-1111')
+          owner.reload
+          expect(owner.phone).to eq('111-111-1111')
+        end
+        it 'sets flash message and redirects to job seeker show page' do
+          patch :update,
+                id: owner,
+                job_seeker: FactoryGirl.attributes_for(:job_seeker)
+          expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
+          expect(response).to redirect_to owner
+        end
+      end
+      context 'unauthorized attributes' do
+        before(:each) do
+          patch :update,
+                id: owner,
+                job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                  year_of_birth: '1988',
+                  password: '123345',
+                  password_confirmation: '123345')
+          owner.reload
+        end
+        it "does not change job seeker's attribute" do
+          expect(owner.year_of_birth).to eq('1998')
+          expect(owner.encrypted_password).to eq password
+        end
+      end
+      context 'invalid attributes' do
+        before(:each) do
+          patch :update,
+                id: owner, 
+                job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                  phone: '123')
+          owner.reload
+        end
+        it "does not change job seeker's attribute" do
+          expect(owner.phone).to eq('123-456-7890')
         end
         it 're-renders the edit template' do
           expect(response).to render_template('edit')
@@ -324,28 +497,52 @@ RSpec.describe JobSeekersController, type: :controller do
   end
 
   describe 'GET #edit' do
-    let(:jobseeker) { FactoryGirl.create(:job_seeker) }
+    let(:agency) { FactoryGirl.create(:agency) }
+    let(:owner_job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
+    let(:owner_case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
+    let(:owner) do 
+      js = FactoryGirl.create(:job_seeker)
+      js.assign_job_developer(owner_job_developer, agency)
+      js.assign_case_manager(owner_case_manager, agency)
+      js
+    end
     let(:resume) do
       FactoryGirl.create(:resume, 
                         file_name: 'Janitor-Resume.doc',
                         file: fixture_file_upload('files/Janitor-Resume.doc'),
-                        job_seeker: jobseeker)
+                        job_seeker: owner)
     end
-    let(:agency) { FactoryGirl.create(:agency) }
-    let(:case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
-
-    context 'edited by job seeker' do
+    let(:request) { get :edit, id: owner }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action', 'visitor'
+    end
+    context 'random agency_person' do
+      it_behaves_like "unauthorized", 'agency_admin'
+      it_behaves_like "unauthorized", 'job_developer'
+      it_behaves_like "unauthorized", 'case_manager'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_person'
+    end
+    context 'random job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'related job developer, related case_manager' do
+      it_behaves_like "authorized to retrieve data", 'owner'
+      it_behaves_like "authorized to retrieve data", 'owner_job_developer'
+      it_behaves_like "authorized to retrieve data", 'owner_case_manager'
+    end
+    context 'owner' do
       before(:each) do
         stub_cruncher_authenticate
         stub_cruncher_file_upload
 
-        sign_in jobseeker
-        get :edit, id: jobseeker
+        sign_in owner
+        request
       end
-
       it 'assigns jobseeker and current_resume for view' do
-        expect(assigns(:jobseeker)).to eq jobseeker
-        expect(assigns(:current_resume)).to eq jobseeker.resumes[0]
+        expect(assigns(:jobseeker)).to eq owner
+        expect(assigns(:current_resume)).to eq owner.resumes[0]
       end
       it 'renders edit template' do
         expect(response).to render_template 'edit'
@@ -354,106 +551,171 @@ RSpec.describe JobSeekersController, type: :controller do
         expect(response).to have_http_status(:success)
       end
     end
-
-    context "edited by job seeker's case manager" do
-      before(:each) do
-        sign_in case_manager
-        jobseeker.assign_case_manager(case_manager, agency)
-        get :edit, id: case_manager.job_seekers.first
-      end
-      it 'renders edit_by_cm template' do
-        expect(response).to render_template 'edit'
-      end
-    end
   end
 
   describe 'GET #home' do
-    let(:jobseeker) { FactoryGirl.create(:job_seeker) }
-    before(:each) do
-      sign_in jobseeker
-      get :home, id: jobseeker
+    let(:owner) { FactoryGirl.create(:job_seeker) }
+    let(:request) { get :home, id: owner }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action', 'visitor'
     end
+    context 'agency_person' do
+      it_behaves_like "unauthorized", 'agency_admin'
+      it_behaves_like "unauthorized", 'job_developer'
+      it_behaves_like "unauthorized", 'case_manager'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_person'
+    end
+    context 'job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'owner' do
+      before :each do
+        sign_in owner
+        request
+      end
+      it 'renders homepage template' do
+        expect(response).to render_template 'home'
+      end
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+      it 'assigns application_type for pagination' do
+        expect(assigns(:application_type)).to eq 'job_seeker'
+      end
+      it 'returns jobs posted since last login' do
+        stub_cruncher_authenticate
+        stub_cruncher_job_create
 
-    it 'renders homepage template' do
-      expect(response).to render_template 'home'
-    end
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
-    end
-    it 'assigns application_type for pagination' do
-      expect(assigns(:application_type)).to eq 'job_seeker'
-    end
-
-    it 'returns jobs posted since last login' do
-      stub_cruncher_authenticate
-      stub_cruncher_job_create
-
-      @newjob = FactoryGirl.create(:job)
-      @newjob.assign_attributes(created_at: Time.now)
-      @oldjob = FactoryGirl.create(:job)
-      @oldjob.update_attributes(created_at: Time.now - 2.weeks)
-      jobseeker.assign_attributes(last_sign_in_at: (Time.now - 1.week))
-      expect(Job.new_jobs(jobseeker.last_sign_in_at)).to include(@newjob)
-      expect(Job.new_jobs(jobseeker.last_sign_in_at)).not_to include(@oldjob)
+        @newjob = FactoryGirl.create(:job)
+        @newjob.assign_attributes(created_at: Time.now)
+        @oldjob = FactoryGirl.create(:job)
+        @oldjob.update_attributes(created_at: Time.now - 2.weeks)
+        owner.assign_attributes(last_sign_in_at: (Time.now - 1.week))
+        expect(Job.new_jobs(owner.last_sign_in_at)).to include(@newjob)
+        expect(Job.new_jobs(owner.last_sign_in_at)).not_to include(@oldjob)
+      end
     end
   end
 
   describe 'GET #index' do
-    let(:admin) { FactoryGirl.create(:agency_admin) }
-    before(:each) do
-      sign_in admin
-      get :index
+    let(:request) { get :index }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action', 'visitor'
+    end
+    context 'agency_person' do
+      it_behaves_like "authorized to retrieve data", 'agency_admin'
+      it_behaves_like "authorized to retrieve data", 'job_developer'
+      it_behaves_like "authorized to retrieve data", 'case_manager'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_admin'
+      it_behaves_like "unauthorized", 'company_contact'
+    end
+    context 'job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
     end
     it 'renders the index template' do
+      sign_in FactoryGirl.create(:agency_admin) 
+      request
       expect(response.body).to render_template 'index'
-    end
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
     end
   end
 
   describe 'GET #show' do
-    let(:jobseeker) { FactoryGirl.create(:job_seeker) }
-    before(:each) do
-      sign_in jobseeker
-      get :show, id: jobseeker
+    let(:owner) { FactoryGirl.create(:job_seeker) }
+    let(:request) { get :show, id: owner }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action', 'visitor'
     end
-    it 'assigns application_type for pagination' do
-      expect(assigns(:application_type)).to eq 'job_seeker'
+    context 'agency_person' do
+      it_behaves_like "authorized to retrieve data", 'agency_admin'
+      it_behaves_like "authorized to retrieve data", 'job_developer'
+      it_behaves_like "authorized to retrieve data", 'case_manager'
     end
-    it 'it renders the show template' do
-      expect(response).to render_template 'show'
+    context 'company_person' do
+      it_behaves_like "authorized to retrieve data", 'company_admin'
+      it_behaves_like "authorized to retrieve data", 'company_contact'
     end
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
+    context 'random job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'owner' do
+      before(:each) do
+        sign_in owner
+        request
+      end
+      it 'assigns application_type for pagination' do
+        expect(assigns(:application_type)).to eq 'job_seeker'
+      end
+      it 'it renders the show template' do
+        expect(response).to render_template 'show'
+      end
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 
   describe 'GET #preview_info' do
     let(:agency) { FactoryGirl.create(:agency) }
-    let(:jobseeker) { FactoryGirl.create(:job_seeker) }
-    let(:job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
-    before(:each) do
-      sign_in job_developer
-      jobseeker.assign_job_developer(job_developer, agency)
-      xhr :get, :preview_info, id: jobseeker
+    let(:owner_job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
+    let(:owner_case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
+    let(:owner) do 
+      js = FactoryGirl.create(:job_seeker)
+      js.assign_job_developer(owner_job_developer, agency)
+      js.assign_case_manager(owner_case_manager, agency)
+      js
     end
-    it "it renders job seeker's info partial" do
-      expect(response).to render_template(partial: '_info')
+    let(:request) { xhr :get, :preview_info, id: owner }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action (xhr)', 'visitor'
+    end
+    context 'random agency_person' do
+      it_behaves_like "unauthorized in xhr", 'agency_admin'
+      it_behaves_like "unauthorized in xhr", 'job_developer'
+      it_behaves_like "unauthorized in xhr", 'case_manager'
+    end
+    context 'company_person' do
+      it_behaves_like "unauthorized in xhr", 'company_person'
+    end
+    context 'job_seeker' do
+      it_behaves_like "unauthorized in xhr", 'job_seeker'
+    end
+    context 'owner, related case_manager' do
+      it_behaves_like "unauthorized in xhr", 'owner'
+      it_behaves_like "unauthorized in xhr", 'owner_case_manager'
+    end
+    context 'related job_developer' do
+      it "it renders job seeker's info partial" do
+        sign_in owner_job_developer
+        request
+        expect(response).to render_template(partial: '_info')
+      end
     end
   end
 
   describe 'DELETE #destroy' do
-    let(:jobseeker) { FactoryGirl.create(:job_seeker) }
-    before(:each) do
-      sign_in jobseeker
-      delete :destroy, id: jobseeker
+    let(:owner) { FactoryGirl.create(:job_seeker) }
+    let(:request) { delete :destroy, id: owner }
+    context 'visitor' do
+      it_behaves_like 'unauthorized action', 'visitor'
     end
-    it 'sets flash message' do
-      expect(flash[:notice]).to eq 'Jobseeker was deleted successfully.'
+    context 'agency_person' do
+      it_behaves_like 'authorized to create / destroy job seeker', 'agency_admin', 'destroy'
+      it_behaves_like "unauthorized", 'job_developer'
+      it_behaves_like "unauthorized", 'case_manager'
     end
-    it 'returns redirect status' do
-      expect(response).to have_http_status(:redirect)
+    context 'company_person' do
+      it_behaves_like "unauthorized", 'company_admin'
+      it_behaves_like "unauthorized", 'company_contact'
+    end
+    context 'random job_seeker' do
+      it_behaves_like "unauthorized", 'job_seeker'
+    end
+    context 'owner' do
+      it_behaves_like 'authorized to create / destroy job seeker', 'owner', 'destroy'
     end
   end
 end

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -15,7 +15,7 @@ module Helpers
     when 'owner_case_manager'
       let(:person) { owner_case_manager }
     when 'company_person', 'company_admin', 'company_contact'
-      let(:person) { FactoryGirl.send(:create, role.to_sym, company: company) } 
+      let(:person) { FactoryGirl.send(:create, role.to_sym, company: company) }
     when 'agency_person', 'job_developer', 'case_manager', 'agency_admin'
       let(:person) { FactoryGirl.send(:create, role.to_sym, agency: agency) }
     else
@@ -28,15 +28,15 @@ module Helpers
     let(:company) { FactoryGirl.create(:company, agencies: [agency]) }
     let(:status) { FactoryGirl.create(:job_seeker_status) }
     let(:valid_attribute) do
-      FactoryGirl.attributes_for(:job_seeker).
-      merge(FactoryGirl.attributes_for(:user)).
-      merge(job_seeker_status_id: status.id).
-      merge(address_attributes: FactoryGirl.attributes_for(:address,
-        zipcode: '12346'))
+      FactoryGirl.attributes_for(:job_seeker)
+                 .merge(FactoryGirl.attributes_for(:user))
+                 .merge(job_seeker_status_id: status.id)
+                 .merge(address_attributes: FactoryGirl.attributes_for(:address,
+                                                                       zipcode: '12346'))
     end
     case role
     when 'owner'
-      let(:person) { owner } 
+      let(:person) { owner }
     when 'agency_person', 'job_developer', 'case_manager', 'agency_admin'
       let(:person) { FactoryGirl.send(:create, role.to_sym, agency: agency) }
     else
@@ -45,11 +45,13 @@ module Helpers
 
     case action
     when 'create'
-      let(:message) { "A message with a confirmation and link has been sent to your email address. " +
-                "Please follow the link to activate your account." }
+      let(:message) do
+        'A message with a confirmation and link has been sent to your email address. ' \
+        'Please follow the link to activate your account.'
+      end
       let(:request) { post :create, job_seeker: valid_attribute }
     when 'destroy'
-      let(:message) { "Jobseeker was deleted successfully." }
+      let(:message) { 'Jobseeker was deleted successfully.' }
       let(:request) { delete :destroy, id: owner }
     else
       let(:message) { nil }
@@ -59,7 +61,7 @@ end
 
 RSpec.configure do |c|
   c.extend Helpers
-end 
+end
 
 RSpec.shared_examples 'unauthorized action' do |role|
   assign_role(role)
@@ -71,25 +73,25 @@ RSpec.shared_examples 'unauthorized action' do |role|
     expect(response).to have_http_status(:redirect)
   end
   it 'sets flash[:alert] message' do
-    expect(flash[:alert]).to eq('You are not authorized to perform this action.').
-    or eq('You need to login to perform this action.')
+    expect(flash[:alert]).to eq('You are not authorized to perform this action.')
+      .or eq('You need to login to perform this action.')
   end
 end
 
-RSpec.shared_examples "unauthorized action (xhr)" do |role|
+RSpec.shared_examples 'unauthorized action (xhr)' do |role|
   assign_role(role)
   before :each do
     warden.set_user person
     request
   end
   it 'returns http unauthorized / forbidden' do
-    expect(response).to have_http_status(:unauthorized).
-    or have_http_status(:forbidden)
+    expect(response).to have_http_status(:unauthorized)
+      .or have_http_status(:forbidden)
   end
   it 'returns unauthenticated / unauthorized message' do
-    expect(JSON.parse(response.body, symbolize_names: true)[:message]).
-    to eq('You need to login to perform this action.').
-    or eq('You are not authorized to perform this action.')
+    expect(JSON.parse(response.body, symbolize_names: true)[:message])
+      .to eq('You need to login to perform this action.')
+      .or eq('You are not authorized to perform this action.')
   end
 end
 
@@ -128,13 +130,13 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'authorized to retrieve data', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like "authorized to retrieve data", 'agency_person'
+      it_behaves_like 'authorized to retrieve data', 'agency_person'
     end
     context 'job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_person'
+      it_behaves_like 'unauthorized', 'company_person'
     end
     it 'renders new template' do
       request
@@ -151,12 +153,12 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'authorized to create / destroy job seeker', 'agency_person', 'create'
     end
     context 'job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_person'
+      it_behaves_like 'unauthorized', 'company_person'
     end
-    
+
     context 'valid attributes' do
       before(:each) do
         js_status = FactoryGirl.create(:job_seeker_status)
@@ -165,7 +167,7 @@ RSpec.describe JobSeekersController, type: :controller do
                               .merge(FactoryGirl.attributes_for(:user))
                               .merge(job_seeker_status_id: js_status.id)
         @js_hash[:address_attributes] = FactoryGirl.attributes_for(:address,
-                                          zipcode: '54321')
+                                                                   zipcode: '54321')
         post :create, job_seeker: @js_hash
       end
       it 'check address' do
@@ -201,9 +203,9 @@ RSpec.describe JobSeekersController, type: :controller do
 
         js_status = FactoryGirl.create(:job_seeker_status)
         @js_hash = FactoryGirl.attributes_for(:job_seeker,
-                    resume: fixture_file_upload('files/Janitor-Resume.doc'))
-                             .merge(FactoryGirl.attributes_for(:user))
-                             .merge(job_seeker_status_id: js_status.id)
+                                              resume: fixture_file_upload('files/Janitor-Resume.doc'))
+                              .merge(FactoryGirl.attributes_for(:user))
+                              .merge(job_seeker_status_id: js_status.id)
       end
 
       it 'saves job seeker' do
@@ -227,16 +229,16 @@ RSpec.describe JobSeekersController, type: :controller do
         @jobseekerstatus.assign_attributes(description: 'MyText')
         @jobseeker.valid?
         js1_hash = FactoryGirl.attributes_for(:job_seeker,
-                      year_of_birth: '198',
-                      resume: fixture_file_upload('files/Janitor-Resume.doc'))
-                    .merge(FactoryGirl.attributes_for(:user,
-                      first_name: 'John',
-                      last_name: 'Smith', 
-                      phone: '890-789-9087'))
-                    .merge(FactoryGirl.attributes_for(:job_seeker_status,
-                      description: 'MyText'))
-                    .merge(FactoryGirl.attributes_for(:address,
-                      zipcode: '12345131231231231231236'))
+                                              year_of_birth: '198',
+                                              resume: fixture_file_upload('files/Janitor-Resume.doc'))
+                              .merge(FactoryGirl.attributes_for(:user,
+                                                                first_name: 'John',
+                                                                last_name: 'Smith',
+                                                                phone: '890-789-9087'))
+                              .merge(FactoryGirl.attributes_for(:job_seeker_status,
+                                                                description: 'MyText'))
+                              .merge(FactoryGirl.attributes_for(:address,
+                                                                zipcode: '12345131231231231231236'))
         post :create, job_seeker: js1_hash
       end
       it 'renders new template' do
@@ -248,11 +250,11 @@ RSpec.describe JobSeekersController, type: :controller do
     end
   end
 
-  describe 'PATCH #update' do 
+  describe 'PATCH #update' do
     let(:agency) { FactoryGirl.create(:agency) }
     let(:owner_job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
     let(:owner_case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
-    let(:owner) do 
+    let(:owner) do
       js = FactoryGirl.create(:job_seeker, phone: '123-456-7890')
       js.assign_job_developer(owner_job_developer, agency)
       js.assign_case_manager(owner_case_manager, agency)
@@ -263,15 +265,15 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized action', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like "unauthorized", 'agency_admin'
-      it_behaves_like "unauthorized", 'job_developer'
-      it_behaves_like "unauthorized", 'case_manager'
+      it_behaves_like 'unauthorized', 'agency_admin'
+      it_behaves_like 'unauthorized', 'job_developer'
+      it_behaves_like 'unauthorized', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_person'
+      it_behaves_like 'unauthorized', 'company_person'
     end
     context 'job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'owner' do
       let(:js_status) { FactoryGirl.create(:job_seeker_status) }
@@ -287,30 +289,30 @@ RSpec.describe JobSeekersController, type: :controller do
             patch :update,
                   id: owner,
                   job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                    resume: fixture_file_upload('files/Janitor-Resume.doc'))
+                                                         resume: fixture_file_upload('files/Janitor-Resume.doc'))
           end.to change(Resume, :count).by(+1)
           expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
         end
       end
       context 'valid attributes without password change' do
         before(:each) do
-          FactoryGirl.create(:resume, 
-            file_name: 'Janitor-Resume.doc',
-            file: fixture_file_upload('files/Janitor-Resume.doc'),
-            job_seeker: owner)
-          patch :update, 
-            id: owner,
-            job_seeker: FactoryGirl.attributes_for(:job_seeker,
-              year_of_birth: '1980', 
-              first_name: 'John',
-              last_name: 'Smith', 
-              password: '',
-              password_confirmation: '', 
-              phone: '780-890-8976',
-              resume: fixture_file_upload('files/Admin-Assistant-Resume.pdf')).
-            merge(job_seeker_status_id: js_status.id).
-            merge(address_attributes: FactoryGirl.attributes_for(:address,
-              zipcode: '12346'))
+          FactoryGirl.create(:resume,
+                             file_name: 'Janitor-Resume.doc',
+                             file: fixture_file_upload('files/Janitor-Resume.doc'),
+                             job_seeker: owner)
+          patch :update,
+                id: owner,
+                job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                       year_of_birth: '1980',
+                                                       first_name: 'John',
+                                                       last_name: 'Smith',
+                                                       password: '',
+                                                       password_confirmation: '',
+                                                       phone: '780-890-8976',
+                                                       resume: fixture_file_upload('files/Admin-Assistant-Resume.pdf'))
+                  .merge(job_seeker_status_id: js_status.id)
+                  .merge(address_attributes: FactoryGirl.attributes_for(:address,
+                                                                        zipcode: '12346'))
           owner.reload
         end
         it 'sets the valid attributes' do
@@ -319,8 +321,8 @@ RSpec.describe JobSeekersController, type: :controller do
           expect(owner.year_of_birth).to eq '1980'
           expect(owner.status.id).to eq js_status.id
           expect(owner.address.zipcode).to eq '12346'
-          expect(owner.resumes[0].file_name).
-          to eq 'Admin-Assistant-Resume.pdf'
+          expect(owner.resumes[0].file_name)
+            .to eq 'Admin-Assistant-Resume.pdf'
         end
         it 'dont change password' do
           expect(owner.encrypted_password).to eq password
@@ -339,13 +341,13 @@ RSpec.describe JobSeekersController, type: :controller do
         render_views
         before(:each) do
           FactoryGirl.create(:resume,
-            file_name: 'Janitor-Resume.doc',
-            file: fixture_file_upload('files/Janitor-Resume.doc'),
-            job_seeker: owner)
-          patch :update, 
+                             file_name: 'Janitor-Resume.doc',
+                             file: fixture_file_upload('files/Janitor-Resume.doc'),
+                             job_seeker: owner)
+          patch :update,
                 id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  resume: fixture_file_upload('files/Example Excel File.xls'))
+                                                       resume: fixture_file_upload('files/Example Excel File.xls'))
           owner.reload
         end
         it 'does not update existing resume' do
@@ -365,8 +367,8 @@ RSpec.describe JobSeekersController, type: :controller do
           patch :update,
                 id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  year_of_birth: '198',
-                  resume: '')
+                                                       year_of_birth: '198',
+                                                       resume: '')
         end
         it 'renders edit template' do
           expect(response).to render_template('edit')
@@ -376,7 +378,7 @@ RSpec.describe JobSeekersController, type: :controller do
         end
       end
     end
-    context " related case manager " do
+    context ' related case manager ' do
       let(:password) { owner.encrypted_password }
       before(:each) do
         sign_in owner_case_manager
@@ -392,7 +394,7 @@ RSpec.describe JobSeekersController, type: :controller do
           patch :update,
                 id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  phone: '111-111-1111')
+                                                       phone: '111-111-1111')
           owner.reload
           expect(owner.phone).to eq('111-111-1111')
         end
@@ -409,9 +411,9 @@ RSpec.describe JobSeekersController, type: :controller do
           patch :update,
                 id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  year_of_birth: '1988',
-                  password: '123345',
-                  password_confirmation: '123345')
+                                                       year_of_birth: '1988',
+                                                       password: '123345',
+                                                       password_confirmation: '123345')
           owner.reload
         end
         it "does not change job seeker's attribute" do
@@ -422,9 +424,9 @@ RSpec.describe JobSeekersController, type: :controller do
       context 'invalid attributes' do
         before(:each) do
           patch :update,
-                id: owner, 
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  phone: '123')
+                                                       phone: '123')
           owner.reload
         end
         it "does not change job seeker's attribute" do
@@ -435,7 +437,7 @@ RSpec.describe JobSeekersController, type: :controller do
         end
       end
     end
-    context " related job_developer " do
+    context ' related job_developer ' do
       let(:password) { owner.encrypted_password }
       before(:each) do
         sign_in owner_job_developer
@@ -451,7 +453,7 @@ RSpec.describe JobSeekersController, type: :controller do
           patch :update,
                 id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  phone: '111-111-1111')
+                                                       phone: '111-111-1111')
           owner.reload
           expect(owner.phone).to eq('111-111-1111')
         end
@@ -468,9 +470,9 @@ RSpec.describe JobSeekersController, type: :controller do
           patch :update,
                 id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  year_of_birth: '1988',
-                  password: '123345',
-                  password_confirmation: '123345')
+                                                       year_of_birth: '1988',
+                                                       password: '123345',
+                                                       password_confirmation: '123345')
           owner.reload
         end
         it "does not change job seeker's attribute" do
@@ -481,9 +483,9 @@ RSpec.describe JobSeekersController, type: :controller do
       context 'invalid attributes' do
         before(:each) do
           patch :update,
-                id: owner, 
+                id: owner,
                 job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                  phone: '123')
+                                                       phone: '123')
           owner.reload
         end
         it "does not change job seeker's attribute" do
@@ -500,37 +502,37 @@ RSpec.describe JobSeekersController, type: :controller do
     let(:agency) { FactoryGirl.create(:agency) }
     let(:owner_job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
     let(:owner_case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
-    let(:owner) do 
+    let(:owner) do
       js = FactoryGirl.create(:job_seeker)
       js.assign_job_developer(owner_job_developer, agency)
       js.assign_case_manager(owner_case_manager, agency)
       js
     end
     let(:resume) do
-      FactoryGirl.create(:resume, 
-                        file_name: 'Janitor-Resume.doc',
-                        file: fixture_file_upload('files/Janitor-Resume.doc'),
-                        job_seeker: owner)
+      FactoryGirl.create(:resume,
+                         file_name: 'Janitor-Resume.doc',
+                         file: fixture_file_upload('files/Janitor-Resume.doc'),
+                         job_seeker: owner)
     end
     let(:request) { get :edit, id: owner }
     context 'visitor' do
       it_behaves_like 'unauthorized action', 'visitor'
     end
     context 'random agency_person' do
-      it_behaves_like "unauthorized", 'agency_admin'
-      it_behaves_like "unauthorized", 'job_developer'
-      it_behaves_like "unauthorized", 'case_manager'
+      it_behaves_like 'unauthorized', 'agency_admin'
+      it_behaves_like 'unauthorized', 'job_developer'
+      it_behaves_like 'unauthorized', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_person'
+      it_behaves_like 'unauthorized', 'company_person'
     end
     context 'random job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'related job developer, related case_manager' do
-      it_behaves_like "authorized to retrieve data", 'owner'
-      it_behaves_like "authorized to retrieve data", 'owner_job_developer'
-      it_behaves_like "authorized to retrieve data", 'owner_case_manager'
+      it_behaves_like 'authorized to retrieve data', 'owner'
+      it_behaves_like 'authorized to retrieve data', 'owner_job_developer'
+      it_behaves_like 'authorized to retrieve data', 'owner_case_manager'
     end
     context 'owner' do
       before(:each) do
@@ -560,15 +562,15 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized action', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like "unauthorized", 'agency_admin'
-      it_behaves_like "unauthorized", 'job_developer'
-      it_behaves_like "unauthorized", 'case_manager'
+      it_behaves_like 'unauthorized', 'agency_admin'
+      it_behaves_like 'unauthorized', 'job_developer'
+      it_behaves_like 'unauthorized', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_person'
+      it_behaves_like 'unauthorized', 'company_person'
     end
     context 'job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'owner' do
       before :each do
@@ -605,19 +607,19 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized action', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like "authorized to retrieve data", 'agency_admin'
-      it_behaves_like "authorized to retrieve data", 'job_developer'
-      it_behaves_like "authorized to retrieve data", 'case_manager'
+      it_behaves_like 'authorized to retrieve data', 'agency_admin'
+      it_behaves_like 'authorized to retrieve data', 'job_developer'
+      it_behaves_like 'authorized to retrieve data', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_admin'
-      it_behaves_like "unauthorized", 'company_contact'
+      it_behaves_like 'unauthorized', 'company_admin'
+      it_behaves_like 'unauthorized', 'company_contact'
     end
     context 'job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     it 'renders the index template' do
-      sign_in FactoryGirl.create(:agency_admin) 
+      sign_in FactoryGirl.create(:agency_admin)
       request
       expect(response.body).to render_template 'index'
     end
@@ -630,16 +632,16 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized action', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like "authorized to retrieve data", 'agency_admin'
-      it_behaves_like "authorized to retrieve data", 'job_developer'
-      it_behaves_like "authorized to retrieve data", 'case_manager'
+      it_behaves_like 'authorized to retrieve data', 'agency_admin'
+      it_behaves_like 'authorized to retrieve data', 'job_developer'
+      it_behaves_like 'authorized to retrieve data', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "authorized to retrieve data", 'company_admin'
-      it_behaves_like "authorized to retrieve data", 'company_contact'
+      it_behaves_like 'authorized to retrieve data', 'company_admin'
+      it_behaves_like 'authorized to retrieve data', 'company_contact'
     end
     context 'random job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'owner' do
       before(:each) do
@@ -662,7 +664,7 @@ RSpec.describe JobSeekersController, type: :controller do
     let(:agency) { FactoryGirl.create(:agency) }
     let(:owner_job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
     let(:owner_case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
-    let(:owner) do 
+    let(:owner) do
       js = FactoryGirl.create(:job_seeker)
       js.assign_job_developer(owner_job_developer, agency)
       js.assign_case_manager(owner_case_manager, agency)
@@ -673,19 +675,19 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized action (xhr)', 'visitor'
     end
     context 'random agency_person' do
-      it_behaves_like "unauthorized in xhr", 'agency_admin'
-      it_behaves_like "unauthorized in xhr", 'job_developer'
-      it_behaves_like "unauthorized in xhr", 'case_manager'
+      it_behaves_like 'unauthorized in xhr', 'agency_admin'
+      it_behaves_like 'unauthorized in xhr', 'job_developer'
+      it_behaves_like 'unauthorized in xhr', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized in xhr", 'company_person'
+      it_behaves_like 'unauthorized in xhr', 'company_person'
     end
     context 'job_seeker' do
-      it_behaves_like "unauthorized in xhr", 'job_seeker'
+      it_behaves_like 'unauthorized in xhr', 'job_seeker'
     end
     context 'owner, related case_manager' do
-      it_behaves_like "unauthorized in xhr", 'owner'
-      it_behaves_like "unauthorized in xhr", 'owner_case_manager'
+      it_behaves_like 'unauthorized in xhr', 'owner'
+      it_behaves_like 'unauthorized in xhr', 'owner_case_manager'
     end
     context 'related job_developer' do
       it "it renders job seeker's info partial" do
@@ -704,15 +706,15 @@ RSpec.describe JobSeekersController, type: :controller do
     end
     context 'agency_person' do
       it_behaves_like 'authorized to create / destroy job seeker', 'agency_admin', 'destroy'
-      it_behaves_like "unauthorized", 'job_developer'
-      it_behaves_like "unauthorized", 'case_manager'
+      it_behaves_like 'unauthorized', 'job_developer'
+      it_behaves_like 'unauthorized', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like "unauthorized", 'company_admin'
-      it_behaves_like "unauthorized", 'company_contact'
+      it_behaves_like 'unauthorized', 'company_admin'
+      it_behaves_like 'unauthorized', 'company_contact'
     end
     context 'random job_seeker' do
-      it_behaves_like "unauthorized", 'job_seeker'
+      it_behaves_like 'unauthorized', 'job_seeker'
     end
     context 'owner' do
       it_behaves_like 'authorized to create / destroy job seeker', 'owner', 'destroy'

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe JobSeekersController, type: :controller do
           expect(jobseeker.first_name).to eq 'John'
           expect(jobseeker.last_name).to eq 'Smith'
           expect(jobseeker.year_of_birth).to eq '1980'
-          expect(jobseeker.status.id) == js_status.id
+          expect(jobseeker.status.id).to eq js_status.id
           expect(jobseeker.address.zipcode).to eq '12346'
           expect(jobseeker.resumes[0].file_name).
           to eq 'Admin-Assistant-Resume.pdf'

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -2,35 +2,34 @@ require 'rails_helper'
 include ServiceStubHelpers::Cruncher
 
 RSpec.describe JobSeekersController, type: :controller do
-
-  describe "GET #new" do
-    it "renders new template" do
+  describe 'GET #new' do
+    it 'renders new template' do
       get :new
       expect(response).to render_template 'new'
     end
-    it "returns http success" do
+    it 'returns http success' do
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "POST #create" do
-    context "valid attributes" do
-       before(:each) do
+  describe 'POST #create' do
+    context 'valid attributes' do
+      before(:each) do
         js_status = FactoryGirl.create(:job_seeker_status)
         ActionMailer::Base.deliveries.clear
-        @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker).
-               merge(FactoryGirl.attributes_for(:user)).
-               merge({:job_seeker_status_id => js_status.id})
+        @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker)
+                                     .merge(FactoryGirl.attributes_for(:user))
+                                     .merge(job_seeker_status_id: js_status.id)
         @jobseeker_hash[:address_attributes] = FactoryGirl.attributes_for(:address, zipcode: '54321')
         post :create, job_seeker: @jobseeker_hash
       end
 
       it 'sets flash message' do
-         expect(flash[:notice]).to eq "A message with a confirmation and link has been sent to your email address. Please follow the link to activate your account."
+        expect(flash[:notice]).to eq 'A message with a confirmation and link has been sent to your email address. Please follow the link to activate your account.'
       end
 
       it 'returns redirect status' do
-         expect(response).to have_http_status(:redirect)
+        expect(response).to have_http_status(:redirect)
       end
       it 'redirects to root page' do
         expect(response).to redirect_to(root_path)
@@ -39,83 +38,82 @@ RSpec.describe JobSeekersController, type: :controller do
         js = User.find_by_email(@jobseeker_hash[:email]).pets_user
         expect(js.address.zipcode).to eq '54321'
       end
-      describe "confirmation email" do
-         # Include email_spec modules here, not in rails_helper because they
-         # conflict with the capybara-email#open_email method which lets us
-         # call current_email.click_link below.
-         # Re: https://github.com/dockyard/capybara-email/issues/34#issuecomment-49528389
-         include EmailSpec::Helpers
-         include EmailSpec::Matchers
+      describe 'confirmation email' do
+        # Include email_spec modules here, not in rails_helper because they
+        # conflict with the capybara-email#open_email method which lets us
+        # call current_email.click_link below.
+        # Re: https://github.com/dockyard/capybara-email/issues/34#issuecomment-49528389
+        include EmailSpec::Helpers
+        include EmailSpec::Matchers
 
-         # open the most recent email sent to user_email
-         subject { open_email(@jobseeker_hash[:email]) }
+        # open the most recent email sent to user_email
+        subject { open_email(@jobseeker_hash[:email]) }
 
-         # Verify email details
-         it { is_expected.to deliver_to(@jobseeker_hash[:email]) }
-         it { is_expected.to have_body_text(/Welcome #{@jobseeker_hash[:first_name]} #{@jobseeker_hash[:last_name]}!/) }
-         it { is_expected.to have_body_text(/You can confirm your account/) }
-         it { is_expected.to have_body_text(/users\/confirmation\?confirmation/) }
-         it { is_expected.to have_subject(/Confirmation instructions/) }
+        # Verify email details
+        it { is_expected.to deliver_to(@jobseeker_hash[:email]) }
+        it { is_expected.to have_body_text(/Welcome #{@jobseeker_hash[:first_name]} #{@jobseeker_hash[:last_name]}!/) }
+        it { is_expected.to have_body_text(/You can confirm your account/) }
+        it { is_expected.to have_body_text(/users\/confirmation\?confirmation/) }
+        it { is_expected.to have_subject(/Confirmation instructions/) }
       end
     end
 
-    context "valid attributes and resume file upload" do
-     before(:each) do
-       stub_cruncher_authenticate
-       stub_cruncher_file_upload
+    context 'valid attributes and resume file upload' do
+      before(:each) do
+        stub_cruncher_authenticate
+        stub_cruncher_file_upload
 
-       ActionMailer::Base.deliveries.clear
+        ActionMailer::Base.deliveries.clear
 
-       js_status = FactoryGirl.create(:job_seeker_status)
-       @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker,
-              resume: fixture_file_upload('files/Janitor-Resume.doc')).
-              merge(FactoryGirl.attributes_for(:user)).
-              merge({:job_seeker_status_id => js_status.id})
-     end
+        js_status = FactoryGirl.create(:job_seeker_status)
+        @jobseeker_hash = FactoryGirl.attributes_for(:job_seeker,
+                                                     resume: fixture_file_upload('files/Janitor-Resume.doc'))
+                                     .merge(FactoryGirl.attributes_for(:user))
+                                     .merge(job_seeker_status_id: js_status.id)
+      end
 
-     it 'saves job seeker' do
-       expect{ post :create, job_seeker: @jobseeker_hash }.
-          to change(JobSeeker, :count).by(+1)
-     end
-     it 'saves resume record' do
-       expect{ post :create, job_seeker: @jobseeker_hash }.
-          to change(Resume, :count).by(+1)
-     end
+      it 'saves job seeker' do
+        expect { post :create, job_seeker: @jobseeker_hash }
+          .to change(JobSeeker, :count).by(+1)
+      end
+      it 'saves resume record' do
+        expect { post :create, job_seeker: @jobseeker_hash }
+          .to change(Resume, :count).by(+1)
+      end
     end
 
     context 'invalid attributes' do
-     before(:each) do
-       @jobseeker = FactoryGirl.create(:job_seeker)
-       @user = FactoryGirl.create(:user)
-       @jobseekerstatus = FactoryGirl.create(:job_seeker_status)
-       @jobseeker.assign_attributes(year_of_birth: '198')
-       @user.assign_attributes(first_name: 'John', last_name: 'Smith',
-                               phone: '890-789-9087')
-       @jobseekerstatus.assign_attributes(description: 'MyText')
-       @jobseeker.valid?
-       jobseeker1_hash = FactoryGirl.attributes_for(:job_seeker,
-            year_of_birth: '198',
-            resume: fixture_file_upload('files/Janitor-Resume.doc')).
-            merge(FactoryGirl.attributes_for(:user, first_name: 'John',
-                   last_name: 'Smith', phone: '890-789-9087')).
-            merge(FactoryGirl.attributes_for(:job_seeker_status,
-                   description:'MyText')).
-           merge(FactoryGirl.attributes_for(:address,
-                                            zipcode: '12345131231231231231236'))
-       post :create, job_seeker: jobseeker1_hash
-
-     end
-     it 'renders new template' do
+      before(:each) do
+        @jobseeker = FactoryGirl.create(:job_seeker)
+        @user = FactoryGirl.create(:user)
+        @jobseekerstatus = FactoryGirl.create(:job_seeker_status)
+        @jobseeker.assign_attributes(year_of_birth: '198')
+        @user.assign_attributes(first_name: 'John', last_name: 'Smith',
+                                phone: '890-789-9087')
+        @jobseekerstatus.assign_attributes(description: 'MyText')
+        @jobseeker.valid?
+        jobseeker1_hash = FactoryGirl.attributes_for(:job_seeker,
+                                                     year_of_birth: '198',
+                                                     resume: fixture_file_upload('files/Janitor-Resume.doc'))
+                                     .merge(FactoryGirl.attributes_for(:user, first_name: 'John',
+                                                                              last_name: 'Smith', phone: '890-789-9087'))
+                                     .merge(FactoryGirl.attributes_for(:job_seeker_status,
+                                                                       description: 'MyText'))
+                                     .merge(FactoryGirl.attributes_for(:address,
+                                                                       zipcode: '12345131231231231231236'))
+        post :create, job_seeker: jobseeker1_hash
+      end
+      it 'renders new template' do
         expect(response).to render_template('new')
-     end
-     it "returns http success" do
+      end
+      it 'returns http success' do
         expect(response).to have_http_status(:success)
-     end
+      end
     end
   end
 
-  describe "PATCH #update" do
-    context " updated by job seeker " do
+  describe 'PATCH #update' do
+    context ' updated by job seeker ' do
       let(:jobseeker) { FactoryGirl.create(:job_seeker) }
       let(:js_status) { FactoryGirl.create(:job_seeker_status) }
       let(:password) { jobseeker.encrypted_password }
@@ -126,44 +124,46 @@ RSpec.describe JobSeekersController, type: :controller do
         sign_in jobseeker
       end
 
-      context "successful initial résumé upload" do
+      context 'successful initial résumé upload' do
         it 'saves the first resume record' do
-          expect{ patch :update, id: jobseeker,
-              job_seeker: FactoryGirl.attributes_for(:job_seeker,
-                resume: fixture_file_upload('files/Janitor-Resume.doc')) }.
-            to change(Resume, :count).by(+1)
-          expect(flash[:notice]).to eq "Jobseeker was updated successfully."
+          expect do
+            patch :update, id: jobseeker,
+                           job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                  resume: fixture_file_upload('files/Janitor-Resume.doc'))
+          end
+            .to change(Resume, :count).by(+1)
+          expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
         end
       end
 
-      context "valid attributes without password change" do 
+      context 'valid attributes without password change' do
         before(:each) do
           FactoryGirl.create(:resume, file_name: 'Janitor-Resume.doc',
-            file: fixture_file_upload('files/Janitor-Resume.doc'), 
-            job_seeker: jobseeker)
+                                      file: fixture_file_upload('files/Janitor-Resume.doc'),
+                                      job_seeker: jobseeker)
           patch :update, id: jobseeker,
-            job_seeker: FactoryGirl.attributes_for(:job_seeker, 
-              year_of_birth: '1980', first_name: 'John', 
-              last_name: 'Smith', password: '', 
-              password_confirmation: '', phone: '780-890-8976',
-              resume: fixture_file_upload('files/Admin-Assistant-Resume.pdf')).
-            merge({ :job_seeker_status_id => js_status.id }).
-            merge({ address_attributes: FactoryGirl.attributes_for(:address, zipcode: '12346') })
+                         job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                year_of_birth: '1980', first_name: 'John',
+                                                                last_name: 'Smith', password: '',
+                                                                password_confirmation: '', phone: '780-890-8976',
+                                                                resume: fixture_file_upload('files/Admin-Assistant-Resume.pdf'))
+                           .merge(job_seeker_status_id: js_status.id)
+                           .merge(address_attributes: FactoryGirl.attributes_for(:address, zipcode: '12346'))
           jobseeker.reload
         end
         it 'sets the valid attributes' do
-          expect(jobseeker.first_name).to eq ("John")
-          expect(jobseeker.last_name).to eq ("Smith")
-          expect(jobseeker.year_of_birth).to eq ("1980")
-          expect(jobseeker.status.id) == (js_status.id)
+          expect(jobseeker.first_name).to eq 'John'
+          expect(jobseeker.last_name).to eq 'Smith'
+          expect(jobseeker.year_of_birth).to eq '1980'
+          expect(jobseeker.status.id) == js_status.id
           expect(jobseeker.address.zipcode).to eq '12346'
           expect(jobseeker.resumes[0].file_name).to eq 'Admin-Assistant-Resume.pdf'
         end
         it 'dont change password' do
-          expect(jobseeker.encrypted_password).to eq (password)
+          expect(jobseeker.encrypted_password).to eq password
         end
         it 'sets flash message' do
-          expect(flash[:notice]).to eq "Jobseeker was updated successfully."
+          expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
         end
         it 'returns redirect status' do
           expect(response).to have_http_status(:redirect)
@@ -173,16 +173,16 @@ RSpec.describe JobSeekersController, type: :controller do
         end
       end
 
-      context "unsuccessful résumé upload" do
+      context 'unsuccessful résumé upload' do
         render_views
 
         before(:each) do
           FactoryGirl.create(:resume, file_name: 'Janitor-Resume.doc',
-            file: fixture_file_upload('files/Janitor-Resume.doc'), 
-            job_seeker: jobseeker)
+                                      file: fixture_file_upload('files/Janitor-Resume.doc'),
+                                      job_seeker: jobseeker)
           patch :update, id: jobseeker,
-            job_seeker: FactoryGirl.attributes_for(:job_seeker,
-            resume: fixture_file_upload('files/Example Excel File.xls'))
+                         job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                resume: fixture_file_upload('files/Example Excel File.xls'))
           jobseeker.reload
         end
         it 'does not update existing resume' do
@@ -200,13 +200,13 @@ RSpec.describe JobSeekersController, type: :controller do
         before(:each) do
           jobseeker.assign_attributes(year_of_birth: '198')
           jobseeker.valid?
-          patch :update, id: jobseeker, job_seeker: FactoryGirl.attributes_for(:job_seeker, 
-            year_of_birth: '198', resume:'')
+          patch :update, id: jobseeker, job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                               year_of_birth: '198', resume: '')
         end
         it 'renders edit template' do
           expect(response).to render_template('edit')
         end
-        it "returns http success" do
+        it 'returns http success' do
           expect(response).to have_http_status(:success)
         end
       end
@@ -221,28 +221,28 @@ RSpec.describe JobSeekersController, type: :controller do
         sign_in case_manager
         jobseeker.assign_case_manager(case_manager, agency)
       end
-      context "valid attributes" do
-        it "locates the requested @jobseeker" do
+      context 'valid attributes' do
+        it 'locates the requested @jobseeker' do
           patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker)
           expect(assigns(:jobseeker)).to eq(jobseeker)
         end
         it "changes @jobseeker's attribute" do
-          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker, 
-            phone: '111-111-1111')
+          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                                                    phone: '111-111-1111')
           jobseeker.reload
           expect(jobseeker.phone).to eq('111-111-1111')
         end
         it 'sets flash message and redirects to job seeker show page' do
           patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker)
-          expect(flash[:notice]).to eq "Jobseeker was updated successfully."
+          expect(flash[:notice]).to eq 'Jobseeker was updated successfully.'
           expect(response).to redirect_to jobseeker
         end
       end
 
-      context "unauthorized attributes" do
+      context 'unauthorized attributes' do
         before(:each) do
-          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker, 
-            year_of_birth: '1988', password: '123345', password_confirmation: '123345')
+          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                                                    year_of_birth: '1988', password: '123345', password_confirmation: '123345')
           jobseeker.reload
         end
         it "does not change job seeker's attribute" do
@@ -251,30 +251,32 @@ RSpec.describe JobSeekersController, type: :controller do
         end
       end
 
-      context "invalid attributes" do
+      context 'invalid attributes' do
         before(:each) do
-          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker, 
-            phone: '123')
+          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker,
+                                                                                                    phone: '123')
           jobseeker.reload
         end
         it "does not change job seeker's attribute" do
           expect(jobseeker.phone).to eq('123-456-7890')
         end
-        it "re-renders the edit template" do
+        it 're-renders the edit template' do
           expect(response).to render_template('edit')
         end
       end
     end
   end
 
-  describe "GET #edit" do
-    let(:jobseeker)  { FactoryGirl.create(:job_seeker) }
-    let(:resume) { FactoryGirl.create(:resume, file_name: 'Janitor-Resume.doc',
-      file: fixture_file_upload('files/Janitor-Resume.doc'), job_seeker: jobseeker) }
+  describe 'GET #edit' do
+    let(:jobseeker) { FactoryGirl.create(:job_seeker) }
+    let(:resume) do
+      FactoryGirl.create(:resume, file_name: 'Janitor-Resume.doc',
+                                  file: fixture_file_upload('files/Janitor-Resume.doc'), job_seeker: jobseeker)
+    end
     let(:agency) { FactoryGirl.create(:agency) }
     let(:case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
-    
-    context "edited by job seeker" do
+
+    context 'edited by job seeker' do
       before(:each) do
         stub_cruncher_authenticate
         stub_cruncher_file_upload
@@ -287,10 +289,10 @@ RSpec.describe JobSeekersController, type: :controller do
         expect(assigns(:jobseeker)).to eq jobseeker
         expect(assigns(:current_resume)).to eq jobseeker.resumes[0]
       end
-      it "renders edit template" do
+      it 'renders edit template' do
         expect(response).to render_template 'edit'
       end
-      it "returns http success" do
+      it 'returns http success' do
         expect(response).to have_http_status(:success)
       end
     end
@@ -301,30 +303,30 @@ RSpec.describe JobSeekersController, type: :controller do
         jobseeker.assign_case_manager(case_manager, agency)
         get :edit, id: case_manager.job_seekers.first
       end
-      it "renders edit_by_cm template" do
+      it 'renders edit_by_cm template' do
         expect(response).to render_template 'edit'
       end
     end
   end
 
-  describe "GET #home" do
+  describe 'GET #home' do
     let(:jobseeker) { FactoryGirl.create(:job_seeker) }
     before(:each) do
       sign_in jobseeker
       get :home, id: jobseeker
     end
 
-    it "renders homepage template" do
+    it 'renders homepage template' do
       expect(response).to render_template 'home'
     end
-    it "returns http success" do
+    it 'returns http success' do
       expect(response).to have_http_status(:success)
     end
     it 'assigns application_type for pagination' do
       expect(assigns(:application_type)).to eq 'job_seeker'
     end
 
-    it "returns jobs posted since last login" do
+    it 'returns jobs posted since last login' do
       stub_cruncher_authenticate
       stub_cruncher_job_create
 
@@ -338,21 +340,21 @@ RSpec.describe JobSeekersController, type: :controller do
     end
   end
 
-  describe "GET #index" do
+  describe 'GET #index' do
     let(:admin) { FactoryGirl.create(:agency_admin) }
     before(:each) do
       sign_in admin
       get :index
     end
-    it "renders the index template" do
+    it 'renders the index template' do
       expect(response.body).to render_template 'index'
     end
-    it "returns http success" do
+    it 'returns http success' do
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET #show" do
+  describe 'GET #show' do
     let(:jobseeker) { FactoryGirl.create(:job_seeker) }
     before(:each) do
       sign_in jobseeker
@@ -361,15 +363,15 @@ RSpec.describe JobSeekersController, type: :controller do
     it 'assigns application_type for pagination' do
       expect(assigns(:application_type)).to eq 'job_seeker'
     end
-    it "it renders the show template" do
+    it 'it renders the show template' do
       expect(response).to render_template 'show'
     end
-    it "returns http success" do
+    it 'returns http success' do
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET #preview_info" do
+  describe 'GET #preview_info' do
     let(:agency) { FactoryGirl.create(:agency) }
     let(:jobseeker) { FactoryGirl.create(:job_seeker) }
     let(:job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
@@ -379,21 +381,21 @@ RSpec.describe JobSeekersController, type: :controller do
       xhr :get, :preview_info, id: jobseeker
     end
     it "it renders job seeker's info partial" do
-      expect(response).to render_template(:partial => '_info')
+      expect(response).to render_template(partial: '_info')
     end
   end
 
-  describe "DELETE #destroy" do
+  describe 'DELETE #destroy' do
     let(:jobseeker) { FactoryGirl.create(:job_seeker) }
     before(:each) do
       sign_in jobseeker
       delete :destroy, id: jobseeker
     end
-    it "sets flash message" do
-        expect(flash[:notice]).to eq "Jobseeker was deleted successfully."
+    it 'sets flash message' do
+      expect(flash[:notice]).to eq 'Jobseeker was deleted successfully.'
     end
-    it "returns redirect status" do
-       expect(response).to have_http_status(:redirect)
+    it 'returns redirect status' do
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe JobSeekersController, type: :controller do
       let(:agency) { FactoryGirl.create(:agency) }
       let(:jobseeker) { FactoryGirl.create(:job_seeker, phone: '123-456-7890') }
       let(:case_manager) { FactoryGirl.create(:case_manager, agency: agency) }
+      let(:password) { jobseeker.encrypted_password }
       before(:each) do
         sign_in case_manager
         jobseeker.assign_case_manager(case_manager, agency)
@@ -235,6 +236,18 @@ RSpec.describe JobSeekersController, type: :controller do
           patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker)
           expect(flash[:notice]).to eq "Jobseeker was updated successfully."
           expect(response).to redirect_to jobseeker
+        end
+      end
+
+      context "unauthorized attributes" do
+        before(:each) do
+          patch :update, id: case_manager.job_seekers.first, job_seeker: FactoryGirl.attributes_for(:job_seeker, 
+            year_of_birth: '1988', password: '123345', password_confirmation: '123345')
+          jobseeker.reload
+        end
+        it "does not change job seeker's attribute" do
+          expect(jobseeker.year_of_birth).to eq('1998')
+          expect(jobseeker.encrypted_password).to eq password
         end
       end
 

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe JobSeekersController, type: :controller do
       expect(response).to have_http_status(:success)
     end
     it 'assigns application_type for pagination' do
-      expect(assigns(:application_type)).to eq 'my-applied'
+      expect(assigns(:application_type)).to eq 'job_seeker'
     end
 
     it "returns jobs posted since last login" do
@@ -359,9 +359,9 @@ RSpec.describe JobSeekersController, type: :controller do
       get :show, id: jobseeker
     end
     it 'assigns application_type for pagination' do
-      expect(assigns(:application_type)).to eq 'js-applied'
+      expect(assigns(:application_type)).to eq 'job_seeker'
     end
-    it "it renders  the show template" do
+    it "it renders the show template" do
       expect(response).to render_template 'show'
     end
     it "returns http success" do
@@ -370,75 +370,17 @@ RSpec.describe JobSeekersController, type: :controller do
   end
 
   describe "GET #preview_info" do
+    let(:agency) { FactoryGirl.create(:agency) }
     let(:jobseeker) { FactoryGirl.create(:job_seeker) }
+    let(:job_developer) { FactoryGirl.create(:job_developer, agency: agency) }
     before(:each) do
-      sign_in jobseeker
+      sign_in job_developer
+      jobseeker.assign_job_developer(job_developer, agency)
       xhr :get, :preview_info, id: jobseeker
     end
     it "it renders job seeker's info partial" do
       expect(response).to render_template(:partial => '_info')
     end
-  end
-
-  describe 'GET #applied_jobs' do
-    let(:job_seeker) { FactoryGirl.create(:job_seeker) }
-    let(:job1) { FactoryGirl.create(:job) }
-    let(:job2) { FactoryGirl.create(:job) }
-    let(:job3) { FactoryGirl.create(:job) }
-    let(:app1) { FactoryGirl.create(:job_application,
-                               job: job1, job_seeker: job_seeker)}
-    let(:app2) { FactoryGirl.create(:job_application,
-                               job: job2, job_seeker: job_seeker)}
-    let(:app3) { FactoryGirl.create(:job_application,
-                               job: job3, job_seeker: job_seeker)}
-    let(:app4) { FactoryGirl.create(:job_application,
-                               job: job3,
-                               job_seeker: FactoryGirl.create(:job_seeker)) }
-
-    context 'JS home page view' do
-      before(:each) do
-        sign_in job_seeker
-        xhr :get, :applied_jobs, id: job_seeker.id, application_type: 'my-applied'
-      end
-
-      it 'assigns application_type for pagination' do
-        expect(assigns(:application_type)).to eq 'my-applied'
-      end
-
-      it 'assigns jobs for view' do
-        stub_cruncher_authenticate
-        stub_cruncher_job_create
-        expect(assigns(:job_applications)).to include(app1, app2, app3)
-        expect(assigns(:job_applications)).not_to include(app4)
-      end
-
-      it 'renders partial for applications' do
-        expect(response).to render_template(partial: 'jobs/_applied_job_list')
-      end
-    end
-
-    context 'JS show page view' do
-      before(:each) do
-        sign_in job_seeker
-        xhr :get, :applied_jobs, id: job_seeker.id, application_type: 'js-applied'
-      end
-
-      it 'assigns application_type for pagination' do
-        expect(assigns(:application_type)).to eq 'js-applied'
-      end
-
-      it 'assigns jobs for view' do
-        stub_cruncher_authenticate
-        stub_cruncher_job_create
-        expect(assigns(:job_applications)).to include(app1, app2, app3)
-        expect(assigns(:job_applications)).not_to include(app4)
-      end
-
-      it 'renders partial for applications' do
-        expect(response).to render_template(partial: 'jobs/_applied_job_list')
-      end
-    end
-
   end
 
   describe "DELETE #destroy" do

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.configure do |c|
   c.extend Helpers
 end
 
-RSpec.shared_examples 'unauthorized action' do |role|
+RSpec.shared_examples 'unauthorized to js controller' do |role|
   assign_role(role)
   before :each do
     warden.set_user person
@@ -133,10 +133,10 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'authorized to retrieve data', 'agency_person'
     end
     context 'job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_person'
+      it_behaves_like 'unauthorized to js controller', 'company_person'
     end
     it 'renders new template' do
       request
@@ -153,10 +153,10 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'authorized to create / destroy job seeker', 'agency_person', 'create'
     end
     context 'job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_person'
+      it_behaves_like 'unauthorized to js controller', 'company_person'
     end
 
     context 'valid attributes' do
@@ -262,18 +262,18 @@ RSpec.describe JobSeekersController, type: :controller do
     end
     let(:request) { patch :update, id: owner }
     context 'visitor' do
-      it_behaves_like 'unauthorized action', 'visitor'
+      it_behaves_like 'unauthorized to js controller', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like 'unauthorized', 'agency_admin'
-      it_behaves_like 'unauthorized', 'job_developer'
-      it_behaves_like 'unauthorized', 'case_manager'
+      it_behaves_like 'unauthorized to js controller', 'agency_admin'
+      it_behaves_like 'unauthorized to js controller', 'job_developer'
+      it_behaves_like 'unauthorized to js controller', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_person'
+      it_behaves_like 'unauthorized to js controller', 'company_person'
     end
     context 'job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'owner' do
       let(:js_status) { FactoryGirl.create(:job_seeker_status) }
@@ -516,18 +516,18 @@ RSpec.describe JobSeekersController, type: :controller do
     end
     let(:request) { get :edit, id: owner }
     context 'visitor' do
-      it_behaves_like 'unauthorized action', 'visitor'
+      it_behaves_like 'unauthorized to js controller', 'visitor'
     end
     context 'random agency_person' do
-      it_behaves_like 'unauthorized', 'agency_admin'
-      it_behaves_like 'unauthorized', 'job_developer'
-      it_behaves_like 'unauthorized', 'case_manager'
+      it_behaves_like 'unauthorized to js controller', 'agency_admin'
+      it_behaves_like 'unauthorized to js controller', 'job_developer'
+      it_behaves_like 'unauthorized to js controller', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_person'
+      it_behaves_like 'unauthorized to js controller', 'company_person'
     end
     context 'random job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'related job developer, related case_manager' do
       it_behaves_like 'authorized to retrieve data', 'owner'
@@ -559,18 +559,18 @@ RSpec.describe JobSeekersController, type: :controller do
     let(:owner) { FactoryGirl.create(:job_seeker) }
     let(:request) { get :home, id: owner }
     context 'visitor' do
-      it_behaves_like 'unauthorized action', 'visitor'
+      it_behaves_like 'unauthorized to js controller', 'visitor'
     end
     context 'agency_person' do
-      it_behaves_like 'unauthorized', 'agency_admin'
-      it_behaves_like 'unauthorized', 'job_developer'
-      it_behaves_like 'unauthorized', 'case_manager'
+      it_behaves_like 'unauthorized to js controller', 'agency_admin'
+      it_behaves_like 'unauthorized to js controller', 'job_developer'
+      it_behaves_like 'unauthorized to js controller', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_person'
+      it_behaves_like 'unauthorized to js controller', 'company_person'
     end
     context 'job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'owner' do
       before :each do
@@ -604,7 +604,7 @@ RSpec.describe JobSeekersController, type: :controller do
   describe 'GET #index' do
     let(:request) { get :index }
     context 'visitor' do
-      it_behaves_like 'unauthorized action', 'visitor'
+      it_behaves_like 'unauthorized to js controller', 'visitor'
     end
     context 'agency_person' do
       it_behaves_like 'authorized to retrieve data', 'agency_admin'
@@ -612,11 +612,11 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'authorized to retrieve data', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_admin'
-      it_behaves_like 'unauthorized', 'company_contact'
+      it_behaves_like 'unauthorized to js controller', 'company_admin'
+      it_behaves_like 'unauthorized to js controller', 'company_contact'
     end
     context 'job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     it 'renders the index template' do
       sign_in FactoryGirl.create(:agency_admin)
@@ -629,7 +629,7 @@ RSpec.describe JobSeekersController, type: :controller do
     let(:owner) { FactoryGirl.create(:job_seeker) }
     let(:request) { get :show, id: owner }
     context 'visitor' do
-      it_behaves_like 'unauthorized action', 'visitor'
+      it_behaves_like 'unauthorized to js controller', 'visitor'
     end
     context 'agency_person' do
       it_behaves_like 'authorized to retrieve data', 'agency_admin'
@@ -641,7 +641,7 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'authorized to retrieve data', 'company_contact'
     end
     context 'random job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'owner' do
       before(:each) do
@@ -675,19 +675,19 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized action (xhr)', 'visitor'
     end
     context 'random agency_person' do
-      it_behaves_like 'unauthorized in xhr', 'agency_admin'
-      it_behaves_like 'unauthorized in xhr', 'job_developer'
-      it_behaves_like 'unauthorized in xhr', 'case_manager'
+      it_behaves_like 'unauthorized action (xhr)', 'agency_admin'
+      it_behaves_like 'unauthorized action (xhr)', 'job_developer'
+      it_behaves_like 'unauthorized action (xhr)', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized in xhr', 'company_person'
+      it_behaves_like 'unauthorized action (xhr)', 'company_person'
     end
     context 'job_seeker' do
-      it_behaves_like 'unauthorized in xhr', 'job_seeker'
+      it_behaves_like 'unauthorized action (xhr)', 'job_seeker'
     end
     context 'owner, related case_manager' do
-      it_behaves_like 'unauthorized in xhr', 'owner'
-      it_behaves_like 'unauthorized in xhr', 'owner_case_manager'
+      it_behaves_like 'unauthorized action (xhr)', 'owner'
+      it_behaves_like 'unauthorized action (xhr)', 'owner_case_manager'
     end
     context 'related job_developer' do
       it "it renders job seeker's info partial" do
@@ -702,19 +702,19 @@ RSpec.describe JobSeekersController, type: :controller do
     let(:owner) { FactoryGirl.create(:job_seeker) }
     let(:request) { delete :destroy, id: owner }
     context 'visitor' do
-      it_behaves_like 'unauthorized action', 'visitor'
+      it_behaves_like 'unauthorized to js controller', 'visitor'
     end
     context 'agency_person' do
       it_behaves_like 'authorized to create / destroy job seeker', 'agency_admin', 'destroy'
-      it_behaves_like 'unauthorized', 'job_developer'
-      it_behaves_like 'unauthorized', 'case_manager'
+      it_behaves_like 'unauthorized to js controller', 'job_developer'
+      it_behaves_like 'unauthorized to js controller', 'case_manager'
     end
     context 'company_person' do
-      it_behaves_like 'unauthorized', 'company_admin'
-      it_behaves_like 'unauthorized', 'company_contact'
+      it_behaves_like 'unauthorized to js controller', 'company_admin'
+      it_behaves_like 'unauthorized to js controller', 'company_contact'
     end
     context 'random job_seeker' do
-      it_behaves_like 'unauthorized', 'job_seeker'
+      it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     context 'owner' do
       it_behaves_like 'authorized to create / destroy job seeker', 'owner', 'destroy'

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -76,12 +76,9 @@ RSpec.describe JobSeekerPolicy do
     it "only allows access if user is account owner" do
       expect(JobSeekerPolicy).to permit(js1, js1)
       expect(JobSeekerPolicy).not_to permit(js2, js1)
-    end
-
-    it "only allow access if user is agency people" do
-      expect(JobSeekerPolicy).to permit(jd1, js1)
-      expect(JobSeekerPolicy).to permit(cm1, js1)
-      expect(JobSeekerPolicy).to permit(admin, js1)
+      expect(JobSeekerPolicy).not_to permit(jd1, js1)
+      expect(JobSeekerPolicy).not_to permit(cm1, js1)
+      expect(JobSeekerPolicy).not_to permit(admin, js1)
       expect(JobSeekerPolicy).not_to permit(cc, js1)
     end
   end

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe JobSeekerPolicy do
   let(:cm2)     { FactoryGirl.create(:case_manager, agency: agency) }
   let(:admin)   { FactoryGirl.create(:agency_admin, agency: agency) }
   let(:cc)      { FactoryGirl.create(:company_contact) }
+  let(:ca)      { FactoryGirl.create(:company_admin) }
 
   permissions :update?, :edit? do
     it "only allows access if user is the account owner" do
@@ -25,6 +26,24 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm2, js1)
       expect(JobSeekerPolicy).not_to permit(jd2, js1)
+      expect(JobSeekerPolicy).not_to permit(admin, js1)
+      expect(JobSeekerPolicy).not_to permit(cc, js1)
+      expect(JobSeekerPolicy).not_to permit(ca, js1)
+    end
+  end
+
+  permissions :create?, :new? do
+    it "only allows access if user is visitor" do
+      expect(JobSeekerPolicy).to permit(visitor, JobSeeker.new)
+    end
+
+    it "only allows access if user is agency people" do
+      expect(JobSeekerPolicy).to permit(jd1, JobSeeker.new)
+      expect(JobSeekerPolicy).to permit(cm1, JobSeeker.new)
+      expect(JobSeekerPolicy).to permit(admin, JobSeeker.new)
+      expect(JobSeekerPolicy).not_to permit(cc, JobSeeker.new)
+      expect(JobSeekerPolicy).not_to permit(ca, JobSeeker.new)
+      expect(JobSeekerPolicy).not_to permit(js1, JobSeeker.new)
     end
   end
 
@@ -41,6 +60,7 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).to permit(cm1, js1)
       expect(JobSeekerPolicy).to permit(admin, js1)
       expect(JobSeekerPolicy).not_to permit(cc, js1)
+      expect(JobSeekerPolicy).not_to permit(ca, js1)
     end
   end
 
@@ -58,6 +78,7 @@ RSpec.describe JobSeekerPolicy do
 
     it "only allow access if user is company people" do
       expect(JobSeekerPolicy).to permit(cc, js1)
+      expect(JobSeekerPolicy).to permit(ca, js1)
     end
   end
 
@@ -68,7 +89,9 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm1, js1)
       expect(JobSeekerPolicy).not_to permit(jd2, js1)
+      expect(JobSeekerPolicy).not_to permit(admin, js1)
       expect(JobSeekerPolicy).not_to permit(cc, js1)
+      expect(JobSeekerPolicy).not_to permit(ca, js1)
     end
   end
 
@@ -83,6 +106,7 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).not_to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm1, js1)
       expect(JobSeekerPolicy).not_to permit(cc, js1)
+      expect(JobSeekerPolicy).not_to permit(ca, js1)
     end
   end
 
@@ -98,6 +122,9 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).not_to permit(js2, js1)
       expect(JobSeekerPolicy).not_to permit(cm1, js1)
       expect(JobSeekerPolicy).not_to permit(jd1, js1)
+      expect(JobSeekerPolicy).not_to permit(admin, js1)
+      expect(JobSeekerPolicy).not_to permit(ca, js1)
+      expect(JobSeekerPolicy).not_to permit(cc, js1)
     end
   end
 end

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe JobSeekerPolicy do
-  
+  let(:visitor) { nil }
   let(:agency)  { FactoryGirl.create(:agency) }
   let(:js1)     { FactoryGirl.create(:job_seeker) }
-  let(:js2)     { FactoryGirl.create(:job_seeker) } 
+  let(:js2)     { FactoryGirl.create(:job_seeker) }
   let(:jd1)     { FactoryGirl.create(:job_developer, agency: agency) }
   let(:jd2)     { FactoryGirl.create(:job_developer, agency: agency) }
-  let(:cm1)      { FactoryGirl.create(:case_manager, agency: agency) }
-  let(:cm2)      { FactoryGirl.create(:case_manager, agency: agency) }
+  let(:cm1)     { FactoryGirl.create(:case_manager, agency: agency) }
+  let(:cm2)     { FactoryGirl.create(:case_manager, agency: agency) }
   let(:admin)   { FactoryGirl.create(:agency_admin, agency: agency) }
   let(:cc)      { FactoryGirl.create(:company_contact) }
 
@@ -18,13 +18,13 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).not_to permit(js2, js1)
     end
 
-    it "only allows access if user is the account owner's case manager" do
+    it "only allows access if user is account owner's case manager or job_developer" do
       js1.assign_case_manager(cm1, agency)
       js1.assign_job_developer(jd1, agency)
       expect(JobSeekerPolicy).to permit(cm1, js1)
+      expect(JobSeekerPolicy).to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm2, js1)
-      expect(JobSeekerPolicy).not_to permit(jd1, js1)
-      expect(JobSeekerPolicy).not_to permit(cc, js1)
+      expect(JobSeekerPolicy).not_to permit(jd2, js1)
     end
   end
 
@@ -83,6 +83,21 @@ RSpec.describe JobSeekerPolicy do
       expect(JobSeekerPolicy).not_to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm1, js1)
       expect(JobSeekerPolicy).not_to permit(cc, js1)
+    end
+  end
+
+  permissions :allow? do
+    it "only allows access if user is visitor" do
+      expect(JobSeekerPolicy).to permit(visitor, JobSeeker.new)
+    end
+
+    it "only allows access if user is account owner" do
+      js1.assign_case_manager(cm1, agency)
+      js1.assign_job_developer(jd1, agency)
+      expect(JobSeekerPolicy).to permit(js1, js1)
+      expect(JobSeekerPolicy).not_to permit(js2, js1)
+      expect(JobSeekerPolicy).not_to permit(cm1, js1)
+      expect(JobSeekerPolicy).not_to permit(jd1, js1)
     end
   end
 end

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -44,7 +44,35 @@ RSpec.describe JobSeekerPolicy do
     end
   end
 
-  permissions :show?, :destroy? do
+  permissions :show? do
+    it "only allows access if user is account owner" do
+      expect(JobSeekerPolicy).to permit(js1, js1)
+      expect(JobSeekerPolicy).not_to permit(js2, js1)
+    end
+
+    it "only allow access if user is agency people" do
+      expect(JobSeekerPolicy).to permit(jd1, js1)
+      expect(JobSeekerPolicy).to permit(cm1, js1)
+      expect(JobSeekerPolicy).to permit(admin, js1)
+    end
+
+    it "only allow access if user is company people" do
+      expect(JobSeekerPolicy).to permit(cc, js1)
+    end
+  end
+
+  permissions :preview_info? do
+    it "only allows access if user is the account owner's job developer" do
+      js1.assign_case_manager(cm1, agency)
+      js1.assign_job_developer(jd1, agency)
+      expect(JobSeekerPolicy).to permit(jd1, js1)
+      expect(JobSeekerPolicy).not_to permit(cm1, js1)
+      expect(JobSeekerPolicy).not_to permit(jd2, js1)
+      expect(JobSeekerPolicy).not_to permit(cc, js1)
+    end
+  end
+
+  permissions :destroy? do
     it "only allows access if user is account owner" do
       expect(JobSeekerPolicy).to permit(js1, js1)
       expect(JobSeekerPolicy).not_to permit(js2, js1)

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe JobSeekerPolicy do
+  
+  let(:agency)  { FactoryGirl.create(:agency) }
+  let(:js1)     { FactoryGirl.create(:job_seeker) }
+  let(:js2)     { FactoryGirl.create(:job_seeker) } 
+  let(:jd1)     { FactoryGirl.create(:job_developer, agency: agency) }
+  let(:jd2)     { FactoryGirl.create(:job_developer, agency: agency) }
+  let(:cm1)      { FactoryGirl.create(:case_manager, agency: agency) }
+  let(:cm2)      { FactoryGirl.create(:case_manager, agency: agency) }
+  let(:admin)   { FactoryGirl.create(:agency_admin, agency: agency) }
+  let(:cc)      { FactoryGirl.create(:company_contact) }
+
+  permissions :update?, :edit? do
+    it "only allows access if user is the account owner" do
+      expect(JobSeekerPolicy).to permit(js1, js1)
+      expect(JobSeekerPolicy).not_to permit(js2, js1)
+    end
+
+    it "only allows access if user is the account owner's case manager" do
+      js1.assign_case_manager(cm1, agency)
+      js1.assign_job_developer(jd1, agency)
+      expect(JobSeekerPolicy).to permit(cm1, js1)
+      expect(JobSeekerPolicy).not_to permit(cm2, js1)
+      expect(JobSeekerPolicy).not_to permit(jd1, js1)
+      expect(JobSeekerPolicy).not_to permit(cc, js1)
+    end
+  end
+
+  permissions :home? do
+    it 'only allows access if user is the account owner' do
+      expect(JobSeekerPolicy).to permit(js1, js1)
+      expect(JobSeekerPolicy).not_to permit(js2, js1)
+    end
+  end
+
+  permissions :index? do
+    it "only allows access if user is agency people" do
+      expect(JobSeekerPolicy).to permit(jd1, js1)
+      expect(JobSeekerPolicy).to permit(cm1, js1)
+      expect(JobSeekerPolicy).to permit(admin, js1)
+      expect(JobSeekerPolicy).not_to permit(cc, js1)
+    end
+  end
+
+  permissions :show?, :destroy? do
+    it "only allows access if user is account owner" do
+      expect(JobSeekerPolicy).to permit(js1, js1)
+      expect(JobSeekerPolicy).not_to permit(js2, js1)
+    end
+
+    it "only allow access if user is agency people" do
+      expect(JobSeekerPolicy).to permit(jd1, js1)
+      expect(JobSeekerPolicy).to permit(cm1, js1)
+      expect(JobSeekerPolicy).to permit(admin, js1)
+      expect(JobSeekerPolicy).not_to permit(cc, js1)
+    end
+  end
+end

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe JobSeekerPolicy do
   let(:ca)      { FactoryGirl.create(:company_admin) }
 
   permissions :update?, :edit? do
-    it "only allows access if user is the account owner" do
+    it 'only allows access if user is the account owner' do
       expect(JobSeekerPolicy).to permit(js1, js1)
       expect(JobSeekerPolicy).not_to permit(js2, js1)
     end
@@ -33,11 +33,11 @@ RSpec.describe JobSeekerPolicy do
   end
 
   permissions :create?, :new? do
-    it "only allows access if user is visitor" do
+    it 'only allows access if user is visitor' do
       expect(JobSeekerPolicy).to permit(visitor, JobSeeker.new)
     end
 
-    it "only allows access if user is agency people" do
+    it 'only allows access if user is agency people' do
       expect(JobSeekerPolicy).to permit(jd1, JobSeeker.new)
       expect(JobSeekerPolicy).to permit(cm1, JobSeeker.new)
       expect(JobSeekerPolicy).to permit(admin, JobSeeker.new)
@@ -55,7 +55,7 @@ RSpec.describe JobSeekerPolicy do
   end
 
   permissions :index? do
-    it "only allows access if user is agency people" do
+    it 'only allows access if user is agency people' do
       expect(JobSeekerPolicy).to permit(jd1, js1)
       expect(JobSeekerPolicy).to permit(cm1, js1)
       expect(JobSeekerPolicy).to permit(admin, js1)
@@ -65,18 +65,18 @@ RSpec.describe JobSeekerPolicy do
   end
 
   permissions :show? do
-    it "only allows access if user is account owner" do
+    it 'only allows access if user is account owner' do
       expect(JobSeekerPolicy).to permit(js1, js1)
       expect(JobSeekerPolicy).not_to permit(js2, js1)
     end
 
-    it "only allow access if user is agency people" do
+    it 'only allow access if user is agency people' do
       expect(JobSeekerPolicy).to permit(jd1, js1)
       expect(JobSeekerPolicy).to permit(cm1, js1)
       expect(JobSeekerPolicy).to permit(admin, js1)
     end
 
-    it "only allow access if user is company people" do
+    it 'only allow access if user is company people' do
       expect(JobSeekerPolicy).to permit(cc, js1)
       expect(JobSeekerPolicy).to permit(ca, js1)
     end
@@ -96,12 +96,12 @@ RSpec.describe JobSeekerPolicy do
   end
 
   permissions :destroy? do
-    it "only allows access if user is account owner" do
+    it 'only allows access if user is account owner' do
       expect(JobSeekerPolicy).to permit(js1, js1)
       expect(JobSeekerPolicy).not_to permit(js2, js1)
     end
 
-    it "only allows access if user is agency admin" do
+    it 'only allows access if user is agency admin' do
       expect(JobSeekerPolicy).to permit(admin, js1)
       expect(JobSeekerPolicy).not_to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm1, js1)
@@ -111,11 +111,11 @@ RSpec.describe JobSeekerPolicy do
   end
 
   permissions :allow? do
-    it "only allows access if user is visitor" do
+    it 'only allows access if user is visitor' do
       expect(JobSeekerPolicy).to permit(visitor, JobSeeker.new)
     end
 
-    it "only allows access if user is account owner" do
+    it 'only allows access if user is account owner' do
       js1.assign_case_manager(cm1, agency)
       js1.assign_job_developer(jd1, agency)
       expect(JobSeekerPolicy).to permit(js1, js1)

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -76,9 +76,12 @@ RSpec.describe JobSeekerPolicy do
     it "only allows access if user is account owner" do
       expect(JobSeekerPolicy).to permit(js1, js1)
       expect(JobSeekerPolicy).not_to permit(js2, js1)
+    end
+
+    it "only allows access if user is agency admin" do
+      expect(JobSeekerPolicy).to permit(admin, js1)
       expect(JobSeekerPolicy).not_to permit(jd1, js1)
       expect(JobSeekerPolicy).not_to permit(cm1, js1)
-      expect(JobSeekerPolicy).not_to permit(admin, js1)
       expect(JobSeekerPolicy).not_to permit(cc, js1)
     end
   end


### PR DESCRIPTION
Conflicts:
In job_seekers_controller.rb, authorize actions consistent with auth matrix
                              auth matrix                         |            current implementation
-  edit / update:     jd + cm + js                       |      cm + js
- destroy:                   js                                  |          aa + js ( there is aa destroy js in feature test)
- applied_job :     moved to job_applications controller
- preview_info:     not include in auth matrix  |    jd

Action #applied_job is moved to job_applications_controller because it can be reused by jobs_controller when implemented with JobApplicationsViewer (existed). 

Question:
1. how should the address behave for job seeker? because currently 'job_seeker belongs_to address' but there is no 'address has_many job_seekers'. it seems that the form will not pop out the address field if the job seeker's address field is empty. refer to job seeker registration form.
