### PR TITLE
Closes AgileVentures/MetPlus_tracker#455

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -12,10 +12,6 @@ class JobApplication < ActiveRecord::Base
     StatusChange.update_status_history(self, :active)
   end
 
-  def status_name
-    status.to_s.camelcase
-  end
-
   def status_change_time(status, which = :latest)
     StatusChange.status_change_time(self, status, which)
   end

--- a/app/views/jobs/_applied_job_list.html.haml
+++ b/app/views/jobs/_applied_job_list.html.haml
@@ -39,7 +39,7 @@
                   = "#{time_ago_in_words(applied_at)} ago"
               - when :status
                 %td
-                  = job_application.status_name
+                  = status_desc(job_application)
 
   = will_paginate job_applications, param_name: 'applications_page',
                                params: {controller: 'job_seekers',

--- a/features/view_job_application.feature
+++ b/features/view_job_application.feature
@@ -3,7 +3,7 @@ Feature: View job application status
 	As a job seeker person
 	I want to view my job application status
 
-Background: data is added to database 
+Background: data is added to database
 
 	Given the default settings are present
 
@@ -24,14 +24,14 @@ Background: data is added to database
     | title        | company_job_id | shift | fulltime | description | company      | creator        | status  |
     | hr assistant | KRK01K         | Day		| true     | internship  | Widgets Inc. | cane@widgets.com | filled  |
     | hr associate | KRK02K         | Day   | true     | internship  | Widgets Inc. | cane@widgets.com | filled  |
-    
+
 	Given the following job applications exist:
 		| job title 	 | job seeker 	 | status 			|
 		| hr assistant | july@seek.com | accepted 		|
 		| hr associate | july@seek.com | not_accepted |
 		| hr associate | john@seek.com | accepted     |
 
-  @javascript 
+  @javascript
   Scenario: Successful and unsuccessful application for job seeker
     Given I am on the home page
     And I login as "july@seek.com" with password "qwerty123"
@@ -40,8 +40,8 @@ Background: data is added to database
     Then I click "hr assistant" link to job show page
     And I should see "hr assistant" show status "filled"
     And I should not see "Click Here To Apply Online"
-    Then I return to my "july@seek.com" home page 
-    And I should see my application for "hr associate" show status "NotAccepted"
+    Then I return to my "july@seek.com" home page
+    And I should see my application for "hr associate" show status "Not Accepted"
     Then I click "hr associate" link to job show page
     And I should see "hr associate" show status "filled"
     And I should not see "Click Here To Apply Online"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -151,29 +151,27 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
-    # describe 'company person' do
-    #   let(:company_person) { FactoryGirl.create(:company_person) }
-    #
-    #   it 'Status 0 should be Pending' do
-    #     company_person.status = 0
-    #     expect(status_desc(company_person)).to eq 'Pending'
-    #   end
-    #   it 'Status 1 should be Invited' do
-    #     company_person.status = 1
-    #     expect(status_desc(company_person)).to eq 'Invited'
-    #   end
-    #   it 'Status 2 should be Active' do
-    #     company_person.status = 2
-    #     expect(status_desc(company_person)).to eq 'Active'
-    #   end
-    #   it 'Status 3 should be Inactive' do
-    #     company_person.status = 3
-    #     expect(status_desc(company_person)).to eq 'Inactive'
-    #   end
-    #   it 'Status 4 should be Registration Denied' do
-    #     company_person.status = 2
-    #     expect(status_desc(company_person)).to eq 'Registration Denied'
-    #   end
-    # end
+    describe 'company person' do
+      it 'Status 0 should be Company Pending' do
+        company_contact.status = 0
+        expect(status_desc(company_contact)).to eq 'Company Pending'
+      end
+      it 'Status 1 should be Invited' do
+        company_contact.status = 1
+        expect(status_desc(company_contact)).to eq 'Invited'
+      end
+      it 'Status 2 should be Active' do
+        company_contact.status = 2
+        expect(status_desc(company_contact)).to eq 'Active'
+      end
+      it 'Status 3 should be Inactive' do
+        company_contact.status = 3
+        expect(status_desc(company_contact)).to eq 'Inactive'
+      end
+      it 'Status 4 should be Company Denied' do
+        company_contact.status = 4
+        expect(status_desc(company_contact)).to eq 'Company Denied'
+      end
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
+
+  let(:company)         { FactoryGirl.create(:company) }
+  let(:company_admin)   { FactoryGirl.create(:company_admin, company: company)}
+  let(:company_contact) { FactoryGirl.create(:company_contact, company: company)}
+  let(:agency)          { FactoryGirl.create(:agency) }
+  let(:case_manager)    { FactoryGirl.create(:case_manager, agency: agency) }
+  let(:job_developer)   { FactoryGirl.create(:job_developer, agency: agency) }
+  let(:agency_admin)    { FactoryGirl.create(:agency_admin, agency: agency) }
+  let(:job_seeker)      { FactoryGirl.create(:job_seeker) }
+  let(:job)             { FactoryGirl.create(:job, company: company) }
+  let(:job_app)         { FactoryGirl.build(:job_application, job: job,
+                                job_seeker: job_seeker, status: :active)}
+
   context 'single_line_address method' do
     it 'returns string for address' do
       address = FactoryGirl.build(:address, :state => "MI")
@@ -27,16 +40,11 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   context '#show_person_path with' do
     describe 'job seeker' do
-      let!(:job_seeker) {FactoryGirl.create(:job_seeker)}
       it 'success' do
         expect(helper.show_person_path job_seeker).to eq(job_seeker_path job_seeker)
       end
     end
     describe 'agency people as' do
-      let!(:agency) {FactoryGirl.create(:agency)}
-      let!(:case_manager) {FactoryGirl.create(:case_manager, :agency => agency)}
-      let!(:job_developer) {FactoryGirl.create(:job_developer, :agency => agency)}
-      let!(:agency_admin) {FactoryGirl.create(:agency_admin, :agency => agency)}
       it 'job developer' do
         expect(helper.show_person_path job_developer).to eq(agency_person_path job_developer)
       end
@@ -48,9 +56,6 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
     describe 'company people as' do
-      let!(:company) {FactoryGirl.create(:company)}
-      let!(:company_admin) {FactoryGirl.create(:company_admin, :company => company)}
-      let!(:company_contact) {FactoryGirl.create(:company_contact, :company => company)}
       it 'company admin' do
         expect(helper.show_person_path company_admin).to eq(company_person_path company_admin)
       end
@@ -67,16 +72,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
     describe 'job seeker' do
-      let!(:job_seeker) {FactoryGirl.create(:job_seeker)}
       it 'success' do
         expect(helper.show_person_home_page_path job_seeker).to eq(home_job_seeker_path job_seeker)
       end
     end
     describe 'agency people as' do
-      let!(:agency) {FactoryGirl.create(:agency)}
-      let!(:case_manager) {FactoryGirl.create(:case_manager, :agency => agency)}
-      let!(:job_developer) {FactoryGirl.create(:job_developer, :agency => agency)}
-      let!(:agency_admin) {FactoryGirl.create(:agency_admin, :agency => agency)}
       it 'job developer' do
         expect(helper.show_person_home_page_path job_developer).to eq(home_agency_person_path(job_developer))
       end
@@ -88,9 +88,6 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
     describe 'company people as' do
-      let!(:company) {FactoryGirl.create(:company)}
-      let!(:company_admin) {FactoryGirl.create(:company_admin, :company => company)}
-      let!(:company_contact) {FactoryGirl.create(:company_contact, :company => company)}
       it 'company admin' do
         expect(helper.show_person_home_page_path company_admin).to eq(home_company_person_path company_admin)
       end
@@ -98,5 +95,85 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.show_person_home_page_path company_contact).to eq(home_company_person_path company_contact)
       end
     end
+  end
+
+  context '#status_desc for status description display' do
+
+    describe 'job application' do
+
+      it 'Status 0 should be Active' do
+        job_app.status = 0
+        expect(status_desc(job_app)).to eq 'Active'
+      end
+      it 'Status 1 should be Accepted' do
+        job_app.status = 1
+        expect(status_desc(job_app)).to eq 'Accepted'
+      end
+      it 'Status 2 should be Not Accepted' do
+        job_app.status = 2
+        expect(status_desc(job_app)).to eq 'Not Accepted'
+      end
+    end
+
+    describe 'agency person' do
+      let(:agency_person) { FactoryGirl.create(:agency_person) }
+
+      it 'Status 0 should be Invited' do
+        agency_person.status = 0
+        expect(status_desc(agency_person)).to eq 'Invited'
+      end
+      it 'Status 1 should be Active' do
+        agency_person.status = 1
+        expect(status_desc(agency_person)).to eq 'Active'
+      end
+      it 'Status 2 should be Inactive' do
+        agency_person.status = 2
+        expect(status_desc(agency_person)).to eq 'Inactive'
+      end
+    end
+
+    describe 'Company' do
+      it 'Status 0 should be Pending Registration' do
+        company.status = 0
+        expect(status_desc(company)).to eq 'Pending Registration'
+      end
+      it 'Status 1 should be Active' do
+        company.status = 1
+        expect(status_desc(company)).to eq 'Active'
+      end
+      it 'Status 2 should be Inactive' do
+        company.status = 2
+        expect(status_desc(company)).to eq 'Inactive'
+      end
+      it 'Status 3 should be Registration Denied' do
+        company.status = 3
+        expect(status_desc(company)).to eq 'Registration Denied'
+      end
+    end
+
+    # describe 'company person' do
+    #   let(:company_person) { FactoryGirl.create(:company_person) }
+    #
+    #   it 'Status 0 should be Pending' do
+    #     company_person.status = 0
+    #     expect(status_desc(company_person)).to eq 'Pending'
+    #   end
+    #   it 'Status 1 should be Invited' do
+    #     company_person.status = 1
+    #     expect(status_desc(company_person)).to eq 'Invited'
+    #   end
+    #   it 'Status 2 should be Active' do
+    #     company_person.status = 2
+    #     expect(status_desc(company_person)).to eq 'Active'
+    #   end
+    #   it 'Status 3 should be Inactive' do
+    #     company_person.status = 3
+    #     expect(status_desc(company_person)).to eq 'Inactive'
+    #   end
+    #   it 'Status 4 should be Registration Denied' do
+    #     company_person.status = 2
+    #     expect(status_desc(company_person)).to eq 'Registration Denied'
+    #   end
+    # end
   end
 end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -43,24 +43,6 @@ RSpec.describe JobApplication, type: :model do
        end
     end
   end
-  describe '#status_name' do
-
-    let(:job_seeker){FactoryGirl.create(:job_seeker)}
-    let(:job){FactoryGirl.create(:job, company: FactoryGirl.create(:company))}
-    subject{FactoryGirl.build(:job_application, job: job, job_seeker: job_seeker, status: :active)}
-    it 'Status 0 should be Active' do
-      subject.status = 0
-      expect(subject.status_name).to eq 'Active'
-    end
-    it 'Status 1 should be Accepted' do
-      subject.status = 1
-      expect(subject.status_name).to eq 'Accepted'
-    end
-    it 'Status 2 should be NotAccepted' do
-      subject.status = 2
-      expect(subject.status_name).to eq 'NotAccepted'
-    end
-  end
 
   describe '#active?' do
     let(:active_job) { FactoryGirl.create(:job) }


### PR DESCRIPTION
The JobApplication model contained this method for returning a string representation of the application status, suitable for display:
```
def status_name
    status.to_s.camelcase
end
```
This method was deleted and instead the common helper method status_desc, defined in application_helper.rb, is used instead.

Also, added method tests to application_helper_spec.rb