### PR TITLE
Using a specific Firefox release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 *~
 *.swp
 
+#ignore rvm version files
+.ruby-version
+.ruby-gemset
+
 # Ignore byebug history
 .byebug_history
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,6 +66,13 @@ WebMock.allow_net_connect!
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Capybara.default_max_wait_time = 5
+# see http://blog.pixarea.com/2013/02/locking-the-firefox-version-when-testing-rails-with-capybara-and-selenium/ for 
+# details on how to set this up
+Capybara.register_driver :selenium do |app|
+  require 'selenium/webdriver'
+  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] || Selenium::WebDriver::Firefox::Binary.path
+  Capybara::Selenium::Driver.new(app, :browser => :firefox)
+end
 
 Before '@selenium' do
   Capybara.current_session.current_window.resize_to(1024, 768)


### PR DESCRIPTION
Allows one to specify the firefox version to execute when running selenium tests. 
Ignore ruby version files when using rvm