### PR TITLE
Spike - #427 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,8 @@ gem 'ransack'
 
 gem 'mailgun_rails'
 
+gem 'docsplit', '~> 0.7.6'
+
 group :development do
   gem 'haml-rails'
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       devise (>= 3.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    docsplit (0.7.6)
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     email_spec (1.6.0)
@@ -357,6 +358,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise (~> 3.5.2)
   devise_invitable (~> 1.5.2)
+  docsplit (~> 0.7.6)
   email_spec
   factory_girl_rails (~> 4.0)
   faker

--- a/app/views/job_seekers/_info.html.haml
+++ b/app/views/job_seekers/_info.html.haml
@@ -36,9 +36,13 @@
           &nbsp; &nbsp (updated #{time_ago_in_words(resume.created_at)} ago)
       %td
         - if offer_download
-          = button_to "Download Resume",
-            download_resume_path(job_seeker.job_applications.last), target: '_self',
+          = button_to "View Resume",
+            job_seeker_path(job_seeker, format: 'pdf'), target: '_self',
             method: :get, class: 'btn btn-success btn-s pull-right'
+        / - if offer_download
+        /   = button_to "Download Resume",
+        /     download_resume_path(job_seeker.job_applications.last), target: '_self',
+        /     method: :get, class: 'btn btn-success btn-s pull-right'
 
 
     %tr

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -201,7 +201,7 @@ if Rails.env.development? || Rails.env.staging?
   addresses = Address.all.to_a
 
   # Create jobs for 'known_company'
-  50.times do |n|
+  25.times do |n|
     Job.create(title: FFaker::Job.title,
                description: Faker::Lorem.sentence,
                shift: %w(Day Evening Morning)[r.rand(3)],
@@ -213,7 +213,7 @@ if Rails.env.development? || Rails.env.staging?
   end
 
   # Create random jobs
-  200.times do |n|
+  100.times do |n|
     title = FFaker::Job.title
     description = Faker::Lorem.paragraph(3, false, 4)
     shift = %w(Day Evening Morning)[r.rand(3)]
@@ -294,6 +294,10 @@ if Rails.env.development? || Rails.env.staging?
                          year_of_birth: '1970', phone: '111-222-3333',
                          job_seeker_status: @jss2, confirmed_at: Time.now,
                          address: create_address)
+  doc_file = File.new('spec/fixtures/files/Janitor-Resume.doc')  
+  doc_resume = Resume.create(file: doc_file,
+                             file_name: 'Janitor-Resume.doc',
+                             job_seeker_id: js2.id)
 
   js3 = JobSeeker.create(first_name: 'Frank', last_name: 'Williams',
                          email: 'fwilliamspets@gmail.com', password: 'qwerty123',


### PR DESCRIPTION
SPIKE: The story creates inline view of job seeker's resume:
- To support .doc, .docx file, they need to be converted to .pdf before render inline.
- This spike uses 'docsplit' gem for the file conversion. https://github.com/documentcloud/docsplit
- mechanism: 
  - it checks the operating system of the user. Then look for office reader: LibreOffice  / OpenOffice in the user machine & Use it to read and convert the file to .pdf
  - there is another one which is using heroku-buildpack-libreoffice.. I havnt figured out yet. Wonder if that refers to the cloud server??
https://github.com/documentcloud/docsplit/blob/master/lib/docsplit/pdf_extractor.rb (line 55)
- Also. need to consider how to manage the created file. want to do conversion once only for every file and render accordingly when needed or convert everytime rendering?

Another way of doing without this libreoffice is to use converter API.. but they will require fee. 
Just curious, Is it possible that  we use 'curl CLI from online conversion website?

To test the following code:
- log in as company person. 
- go to /job_seekers/202 for .doc file, /job_seekers/203 for .docx file. 
- Right now the converted file is stored in .tmp. and they are not deleted after created.


