### PR TITLE
Closes AgileVentures/MetPlus_tracker#502

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,9 @@
 # Ignore application configuration
 /config/application.yml
 
-
 # Ignore Editor files
 .idea/*
 
+/spec/examples.txt
 
 .DS_Store

--- a/app/models/job_skill.rb
+++ b/app/models/job_skill.rb
@@ -1,6 +1,6 @@
 class JobSkill < ActiveRecord::Base
   belongs_to :job, inverse_of: :job_skills
-  belongs_to :skill
+  belongs_to :skill, counter_cache: :jobs_count
 
   validates_presence_of :job, :skill
   validates_uniqueness_of :skill_id, scope: :job_id

--- a/db/migrate/20161227034829_add_jobs_count_to_skills.rb
+++ b/db/migrate/20161227034829_add_jobs_count_to_skills.rb
@@ -1,0 +1,5 @@
+class AddJobsCountToSkills < ActiveRecord::Migration
+  def change
+    add_column :skills, :jobs_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20161227035153_cache_jobs_count.rb
+++ b/db/migrate/20161227035153_cache_jobs_count.rb
@@ -1,0 +1,5 @@
+class CacheJobsCount < ActiveRecord::Migration
+  def change
+    execute "UPDATE skills SET jobs_count=(SELECT count(*) FROM job_skills WHERE job_skills.skill_id=skills.id)"
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -67,7 +67,7 @@ WebMock.allow_net_connect!
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
-Capybara.default_max_wait_time = 5
+Capybara.default_max_wait_time = 10
 # see http://blog.pixarea.com/2013/02/locking-the-firefox-version-when-testing-rails-with-capybara-and-selenium/ for
 # details on how to set this up
 Capybara.register_driver :selenium do |app|

--- a/spec/models/job_seeker_spec.rb
+++ b/spec/models/job_seeker_spec.rb
@@ -23,7 +23,7 @@ describe JobSeeker, type: :model do
     it { is_expected.to belong_to(:address) }
     it { is_expected.to belong_to(:job_seeker_status) }
 
-    it { should allow_value('1987', '1916', '2000', '2014').for(:year_of_birth) }
+    it { should allow_value('1987', '2000', '2014').for(:year_of_birth) }
     it { should_not allow_value('1911', '899', '1890', 'salem').for(:year_of_birth) }
   end
 

--- a/spec/models/skill_spec.rb
+++ b/spec/models/skill_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Skill, type: :model do
   end
 
   describe 'Validations' do
-    subject {FactoryGirl.build(:skill)}
+    subject { FactoryGirl.build(:skill) }
 
     describe 'Name' do
       it { is_expected.to validate_presence_of(:name) }
@@ -43,7 +43,7 @@ RSpec.describe Skill, type: :model do
       phone_operator = FactoryGirl.create(:job)
       speak_english = FactoryGirl.create(:skill)
       JobSkill.create(job: waiter, skill: speak_english, min_years: 0, max_years: 10)
-      JobSkill.create(job: phone_operator, skill: speak_english, min_years: 0, 
+      JobSkill.create(job: phone_operator, skill: speak_english, min_years: 0,
                       max_years: 10)
       expect(speak_english.jobs_count).to eql 2
       expect(speak_english.jobs_count).to eql speak_english.jobs.count

--- a/spec/models/skill_spec.rb
+++ b/spec/models/skill_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+include ServiceStubHelpers::Cruncher
 
 RSpec.describe Skill, type: :model do
   describe 'Fixtures' do
@@ -28,5 +29,24 @@ RSpec.describe Skill, type: :model do
     it { is_expected.to have_db_column :id }
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :jobs_count }
+  end
+
+  describe 'counter_cache' do
+    before(:each) do
+      stub_cruncher_authenticate
+      stub_cruncher_job_create
+    end
+
+    it 'increments jobs_count when a new row is created in job_skill table' do
+      waiter = FactoryGirl.create(:job)
+      phone_operator = FactoryGirl.create(:job)
+      speak_english = FactoryGirl.create(:skill)
+      JobSkill.create(job: waiter, skill: speak_english, min_years: 0, max_years: 10)
+      JobSkill.create(job: phone_operator, skill: speak_english, min_years: 0, 
+                      max_years: 10)
+      expect(speak_english.jobs_count).to eql 2
+      expect(speak_english.jobs_count).to eql speak_english.jobs.count
+    end
   end
 end


### PR DESCRIPTION
Issue:
- 'bullet' complains about < N+1 Query method call stack /app/models/skill.rb:13:in 'has_job?' >
- '#has_job?' calls 'jobs.any?' which relates to 'jobs.count'

Completed:
- jobs_count COLUMN is added to skills TABLE
- counter_cache OPTIONS is added to JobSkill CLASS
- spec test added
