### PR TITLE
Closed AgileVentures/MetPlus_tracker#586

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ gem 'rest-client'
 
 gem 'cocoon'
 gem 'pg'
-gem 'tilt', '>= 1.3.4', '~> 1.3'
 
 # later we can strict the faker
 # to staging && development

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ gem 'json'
 gem 'rest-client'
 
 gem 'cocoon'
+gem 'pg'
+gem 'tilt', '>= 1.3.4', '~> 1.3'
 
 # later we can strict the faker
 # to staging && development
@@ -86,8 +88,7 @@ group :development do
 end
 
 group :development, :test do
-  # Use sqlite3 as the database for Active Record
-  gem 'sqlite3'
+
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
@@ -119,8 +120,6 @@ end
 
 gem 'airbrake', '~> 5.4'
 group :production do
-  # Use Postgres as the database for Active Record
-  gem 'pg'
   gem 'rails_12factor'
   gem 'puma'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,7 +388,6 @@ DEPENDENCIES
   shoulda-matchers!
   simplecov
   spring
-  tilt (~> 1.3, >= 1.3.4)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,10 +306,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (1.4.1)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -389,7 +388,7 @@ DEPENDENCIES
   shoulda-matchers!
   simplecov
   spring
-  sqlite3
+  tilt (~> 1.3, >= 1.3.4)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.2)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,20 +5,21 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: metplus_pets_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test: &test
   <<: *default
-  database: db/test.sqlite3
+  database: metplus_pets_test
 
 production:
   <<: *default


### PR DESCRIPTION
Database for development and test is changed to pg.
But I did rake db:drop to recreate the database instead of getting a proper migration.
There is a reference which use 'taps' to do database migration, which i failed to follow due to rack version problem :https://medium.com/@helenflam/how-to-change-your-rails-app-database-from-sqlite-to-postgresql-before-deploying-to-heroku-ae2acc25c7ac#.ufvq6tmfa
