### PR TITLE
Closes AgileVentures/MetPlus_tracker #560

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -238,7 +238,6 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_ENV'] == 'STAGING
                          job_seeker_status: @jss1, confirmed_at: Time.now,
                          address: create_address)
 
-
   # Have this JS apply to every other known_company jobs
   Job.where(company: known_company).each do |job|
     JobApplication.create(job: job, job_seeker: js1) unless job.id.even?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -238,6 +238,7 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_ENV'] == 'STAGING
                          job_seeker_status: @jss1, confirmed_at: Time.now,
                          address: create_address)
 
+
   # Have this JS apply to every other known_company jobs
   Job.where(company: known_company).each do |job|
     JobApplication.create(job: job, job_seeker: js1) unless job.id.even?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe User, type: :model do
 
          user = FactoryGirl.build(:user, email: 'emailaddress@gmal.com')
          user.valid?
-         expect(user.errors[:email]).to include('is not valid (did you mean\
-                                                  ... myaddress@gmail.com?)')
+         expect(user.errors[:email]).to include(
+           'is not valid (did you mean ... myaddress@gmail.com?)')
        end
      end
    end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe User, type: :model do
 
          user = FactoryGirl.build(:user, email: 'emailaddress@gmal.com')
          user.valid?
-         expect(user.errors[:email]).to include("is not valid (did you mean ... myaddress@gmail.com?)")
+         expect(user.errors[:email]).to include('is not valid (did you mean ... myaddress@gmail.com?)')
        end
      end
    end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe User, type: :model do
 
          user = FactoryGirl.build(:user, email: 'emailaddress@gmal.com')
          user.valid?
-         expect(user.errors[:email]).to include(
-           'is not valid (did you mean ... myaddress@gmail.com?)')
+         expect(user.errors[:email]).to include('is not valid (did you mean ... 
+                                                myaddress@gmail.com?)')
        end
      end
    end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe User, type: :model do
 
          user = FactoryGirl.build(:user, email: 'emailaddress@gmal.com')
          user.valid?
-         expect(user.errors[:email]).to include('is not valid (did you mean ... myaddress@gmail.com?)')
+         expect(user.errors[:email]).to include('is not valid (did you mean\
+                                                  ... myaddress@gmail.com?)')
        end
      end
    end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe User, type: :model do
 
          user = FactoryGirl.build(:user, email: 'emailaddress@gmal.com')
          user.valid?
-         expect(user.errors[:email]).to include('is not valid (did you mean ... 
+         expect(user.errors[:email]).to include('is not valid (did you mean ...
                                                 myaddress@gmail.com?)')
        end
      end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe User, type: :model do
          user.email = 'emailaddress@gmal.com'
          expect(user).to be_valid
        end
+
+       it 'adds an error to object when validation fails' do
+         stub_email_validate_invalid
+
+         user = FactoryGirl.build(:user, email: 'emailaddress@gmal.com')
+         user.valid?
+         expect(user.errors[:email]).to include("is not valid (did you mean ... myaddress@gmail.com?)")
+       end
      end
    end
 


### PR DESCRIPTION
This adds a test for a failed email validation. 

Due to the failing validation, I had to instantiate a new instance of user inside the `it` block, because ActiveRecord was not letting the test run. 

This test only covers a case where the non-valid email resembles a valid one, which would populate the `did_you_mean` field of the API response. A case where that field is not populated (i.e. if the email doesn't resemble anything) is not covered by this test.

Thanks to @Thomascountz for the assistance. This is my first PR ever, so please go easy on me. 