### PR TITLE
allow agency persons to download resumes

### DIFF
--- a/app/controllers/job_seekers_controller.rb
+++ b/app/controllers/job_seekers_controller.rb
@@ -112,7 +112,7 @@ class JobSeekersController < ApplicationController
   def show
     @jobseeker = JobSeeker.find(params[:id])
     authorize @jobseeker
-    @offer_download = pets_user.is_a?(CompanyPerson)
+    @offer_download = pets_user.is_a?(CompanyPerson) || pets_user.is_a?(AgencyPerson)
   end
 
   def preview_info

--- a/app/policies/job_seeker_policy.rb
+++ b/app/policies/job_seeker_policy.rb
@@ -62,32 +62,32 @@ class JobSeekerPolicy < ApplicationPolicy
 
   def permitted_attributes
     if user == record
-      [ :first_name,
-        :last_name,
-        :email,
-        :phone,
-        :password,
-        :password_confirmation,
-        :year_of_birth,
-        :resume,
-        :consent,
-        :job_seeker_status_id,
-        address_attributes: [:id, :street, :city, :zipcode, :state]
-      ]
+      [:first_name,
+       :last_name,
+       :email,
+       :phone,
+       :password,
+       :password_confirmation,
+       :year_of_birth,
+       :resume,
+       :consent,
+       :job_seeker_status_id,
+       address_attributes: [:id, :street, :city, :zipcode, :state]]
     elsif (user == record.case_manager) || (user == record.job_developer)
-      [ :first_name,
-        :last_name,
-        :email,
-        :phone,
-        :resume,
-        :consent,
-        :job_seeker_status_id,
-        address_attributes: [:id, :street, :city, :zipcode, :state]
-      ]
+      [:first_name,
+       :last_name,
+       :email,
+       :phone,
+       :resume,
+       :consent,
+       :job_seeker_status_id,
+       address_attributes: [:id, :street, :city, :zipcode, :state]]
     end
   end
+
   def download_resume?
-    User.is_company_person?(user) &&
-    record.job_applications.where(job: user.company.jobs.active).exists?
+    user.is_a?(AgencyPerson) ||
+      User.is_company_person?(user) &&
+        record.job_applications.where(job: user.company.jobs.active).exists?
   end
 end

--- a/features/job_seeker.feature
+++ b/features/job_seeker.feature
@@ -158,6 +158,13 @@ Scenario: Agency and Company people actions
   And I should see "Doctor"
   And I should see "Mime"
   And I should not see "Trucker"
+  
+  # agency person: download job seeker résumé
+  Then I am on the JobSeeker Show page for "mike.smith@gmail.com"
+  And I wait 1 second
+  Then I should see button "Download Resume"
+  And I click the "Download Resume" button
+  Then I should get a download with the filename "Janitor-Resume.doc"
 
   # company admin: download job seeker résumé
   And I click the "Hello, John" link

--- a/spec/policies/job_seeker_policy_spec.rb
+++ b/spec/policies/job_seeker_policy_spec.rb
@@ -171,16 +171,16 @@ RSpec.describe JobSeekerPolicy do
       FactoryGirl.create(:job_application, job: job, job_seeker: js1)
     end
 
-    it 'allows access if user is a company admin/contact' do
+    it 'allows access if user is a company admin/contact or agency person' do
       expect(JobSeekerPolicy).to permit(ca, js1)
       expect(JobSeekerPolicy).to permit(cc, js1)
+      expect(JobSeekerPolicy).to permit(jd1, js1)
+      expect(JobSeekerPolicy).to permit(cm1, js1)
+      expect(JobSeekerPolicy).to permit(admin, js1)
     end
 
-    it 'denies access if user is not a company admin/contact' do
+    it 'denies access if user is not a company admin/contact or agency person' do
       expect(JobSeekerPolicy).not_to permit(js1, js1)
-      expect(JobSeekerPolicy).not_to permit(admin, js1)
-      expect(JobSeekerPolicy).not_to permit(jd1, js1)
-      expect(JobSeekerPolicy).not_to permit(cm1, js1)
     end
 
     it 'denies company people of the wrong company' do


### PR DESCRIPTION
Changed the policy and controller to enable Agency persons to download jobseeker resumes.  