### PR TITLE
download JS resume button changes to view, controller and feature test

### DIFF
--- a/app/controllers/job_seekers_controller.rb
+++ b/app/controllers/job_seekers_controller.rb
@@ -112,7 +112,8 @@ class JobSeekersController < ApplicationController
   def show
     @jobseeker = JobSeeker.find(params[:id])
     authorize @jobseeker
-    @offer_download = pets_user.is_a?(CompanyPerson) || pets_user.is_a?(AgencyPerson)
+    @offer_download = @jobseeker.resumes.exists? &&
+                      (pets_user.is_a?(CompanyPerson) || pets_user.is_a?(AgencyPerson))
   end
 
   def preview_info

--- a/app/views/job_seekers/_info.html.haml
+++ b/app/views/job_seekers/_info.html.haml
@@ -39,7 +39,7 @@
         - if offer_download
           = button_to "Download Resume",
             download_resume_path(@jobseeker.id, @jobseeker.resumes[0]), target: '_self',
-            method: :get, class: 'btn btn-success btn-s pull-right'
+            method: :get, class: 'btn btn-success btn-xs pull-right'
     %tr
       %td
         %strong Case Manager

--- a/features/job_seeker.feature
+++ b/features/job_seeker.feature
@@ -159,6 +159,11 @@ Scenario: Agency and Company people actions
   And I should see "Mime"
   And I should not see "Trucker"
   
+  # agency person: no download button when no job seeker résumé
+  Then I am on the JobSeeker Show page for "tommy1@gmail.com"
+  And I wait 1 second
+  Then I should not see button "Download Resume"
+  
   # agency person: download job seeker résumé
   Then I am on the JobSeeker Show page for "mike.smith@gmail.com"
   And I wait 1 second


### PR DESCRIPTION
Added condition to Job_seeker_controller that a job seeker must have at least one resume before the download button will appear.  Adjusted the size of the download button to be the same as that of the 'Assign Me' button.  Added a feature test to verify that the download button does not appear for a job seeker with no resume. 