### PR TITLE
Remove fulltime from jobs

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -402,7 +402,7 @@ class JobsController < ApplicationController
 
   def job_params
     params.require(:job).permit(:description, :company_job_id,
-                                :fulltime, :company_id, :title, :address_id,
+                                :company_id, :title, :address_id,
                                 :company_person_id, :years_of_experience,
                                 :pay_period, :max_salary, :min_salary,
                                 job_type_ids: [], job_shift_ids: [],

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -43,7 +43,6 @@ class Job < ActiveRecord::Base
   YEARS_OF_EXPERIENCE_OPTIONS = (0..20).to_a.freeze
   validates_presence_of :title
   validates_presence_of :company_job_id
-  validates_presence_of :fulltime, allow_blank: true
   validates_length_of   :title, maximum: 100
   validates_presence_of :description
   validates_length_of   :description, maximum: 10_000

--- a/app/views/jobs/_job_info.html.haml
+++ b/app/views/jobs/_job_info.html.haml
@@ -21,9 +21,6 @@
         %td No address for this job
 
     %tr
-      %td Full time:
-      %td=@job.fulltime ? 'Yes' : 'No'
-    %tr
       %td Job ID:
       %td=@job.company_job_id
     - unless @job.years_of_experience.blank?

--- a/db/migrate/20171012061143_remove_fulltime_from_jobs.rb
+++ b/db/migrate/20171012061143_remove_fulltime_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveFulltimeFromJobs < ActiveRecord::Migration
+  def change
+    remove_column :jobs, :fulltime
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -237,7 +237,6 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_ENV'] == 'STAGING
     Job.create(title: FFaker::Job.title,
                description: Faker::Lorem.sentence,
                company_job_id: "Job_ID_#{n}",
-               fulltime: [false, true][r.rand(2)],
                company_id: known_company.id,
                company_person_id: known_company_person.id,
                address_id: known_company.addresses[r.rand(15)].id)
@@ -247,13 +246,11 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_ENV'] == 'STAGING
   20.times do |n|
     title = FFaker::Job.title
     description = Faker::Lorem.paragraph(3, false, 4)
-    fulltime = [false, true][r.rand(2)]
     job_id = ((1..9).to_a + ('A'..'Z').to_a).sample(8).join
     # debugger
     Job.create(title: title,
                description: description,
                company_job_id: job_id,
-               fulltime: fulltime,
                company_id: companies[n].id,
                company_person_id: companypeople[n].id,
                job_category_id: jobcategories[n].id,

--- a/features/accept_job_application.feature
+++ b/features/accept_job_application.feature
@@ -32,9 +32,9 @@ Background: data is added to database
     | june@ymail.com | dave@metplus.org | JD   |
 
   Given the following jobs exist:
-    | title        | company_job_id | fulltime | description | company      | creator          |
-    | hr manager   | KRK02K         | true     | internship  | Widgets Inc. | cane@ymail.com |
-    | hr assistant | KRK01K       | true     | internship  | Widgets Inc. | cane@ymail.com |
+    | title        | company_job_id | description | company      | creator          |
+    | hr manager   | KRK02K         | internship  | Widgets Inc. | cane@ymail.com |
+    | hr assistant | KRK01K         | internship  | Widgets Inc. | cane@ymail.com |
 
   Given the following job applications exist:
     | job title      | job seeker    | status       |
@@ -52,7 +52,7 @@ Background: data is added to database
     Then I accept "jane@ymail.com" application for "hr manager"
     And I should see an "accept" confirmation
     Then I click the "Accept" confirmation
-    And I wait 1 second 
+    And I wait 1 second
     And I should see "jane@ymail.com" application is listed first
     And I should see "jane@ymail.com" application for "hr manager" changes to accepted
     And other applications for "hr manager" change to not accepted

--- a/features/agency_admin.feature
+++ b/features/agency_admin.feature
@@ -39,8 +39,8 @@ Background: seed data added to database and log in as agency admim
     | Widgets Inc. | CC    | Jane       | Smith     | jane@ymail.com | qwerty123 | 555-222-3334 |
 
   Given the following jobs exist:
-  | title         | company_job_id  | fulltime | description | company      | creator          | skills    |
-  | Web dev       | KRK01K          | true     | internship  | Widgets Inc. | jane@ymail.com | Web Research |
+  | title         | company_job_id  | description | company      | creator          | skills    |
+  | Web dev       | KRK01K          | internship  | Widgets Inc. | jane@ymail.com | Web Research |
 
   Given the following jobseekers exist:
   | first_name| last_name| email            | phone       | password  | year_of_birth |job_seeker_status  |

--- a/features/company_person.feature
+++ b/features/company_person.feature
@@ -54,8 +54,8 @@ Feature: Company Person
       | job_application    | jane@ymail.com     | 2016-03-10    | ASSIGNED    | john-seeker@gmail.com |
 
     Given the following jobs exist:
-    | title         | company_job_id  | fulltime | description | company      | creator          | skills    |
-    | Web dev       | KRK01K          | true     | internship  | Widgets Inc. | jane@ymail.com | Web Research |
+    | title         | company_job_id  | description | company      | creator          | skills    |
+    | Web dev       | KRK01K          | internship  | Widgets Inc. | jane@ymail.com | Web Research |
 
   Scenario: company admin edits company info
     Given I am on the home page

--- a/features/company_person_jobs_view.feature
+++ b/features/company_person_jobs_view.feature
@@ -23,10 +23,10 @@ Feature: Company Person Jobs View
       | Feature Inc. | CA    | Charles    | Daniel    | ca@feature.com   | qwerty123 | 555-222-3334 |
 
     Given the following jobs exist:
-      | title        | company_job_id  | fulltime | description| company      | creator          |
-      | software dev | KRK01K          | true     | internship | Widgets Inc. | carter@ymail.com |
-      | Cook         | KRK11K          | true     | internship | Feature Inc. | ca@feature.com   |
-      | Doctor       | AAEE1K          | true     | internship | Feature Inc. | ca@feature.com   |
+      | title        | company_job_id  | description| company      | creator          |
+      | software dev | KRK01K          | internship | Widgets Inc. | carter@ymail.com |
+      | Cook         | KRK11K          | internship | Feature Inc. | ca@feature.com   |
+      | Doctor       | AAEE1K          | internship | Feature Inc. | ca@feature.com   |
 
   @javascript
   Scenario: verify job listing in home page

--- a/features/job_application.feature
+++ b/features/job_application.feature
@@ -23,8 +23,8 @@ Given the following company people exist:
   | Widgets Inc. | CC    | Jane       | Smith     | jane@ymail.com | qwerty123 | 555-222-3334 |
 
 Given the following jobs exist:
-  | title               | company_job_id  | fulltime | description                 | company      | creator        |
-  | software developer  | KRK01K          | true     | internship position with pay| Widgets Inc. | carter@ymail.com |
+  | title               | company_job_id  | description                 | company      | creator        |
+  | software developer  | KRK01K          | internship position with pay| Widgets Inc. | carter@ymail.com |
 
 Given the following jobseekers exist:
   | first_name| last_name| email                     | phone       | password   |password_confirmation| year_of_birth |job_seeker_status |

--- a/features/job_application_by_jd.feature
+++ b/features/job_application_by_jd.feature
@@ -22,8 +22,8 @@ Background: data is added to database
   | Widgets Inc. | CA    | John       | Smith     | carter@ymail.com   | qwerty123 | 555-222-3334 |
 
   Given the following jobs exist:
-  | title               | company_job_id  | fulltime | description                 | company      | creator        |
-  | software developer  | KRK01K          | true     | internship position with pay| Widgets Inc. | carter@ymail.com |
+  | title               | company_job_id  | description                 | company      | creator        |
+  | software developer  | KRK01K          | internship position with pay| Widgets Inc. | carter@ymail.com |
 
   Given the following jobseekers exist:
   | first_name| last_name| email                     | phone       | password   |password_confirmation| year_of_birth |job_seeker_status |

--- a/features/job_seeker.feature
+++ b/features/job_seeker.feature
@@ -24,12 +24,12 @@ Background: seed data added to database
     | Widgets Inc. | CA    | John       | Smith     | carter@ymail.com | qwerty123 | 555-222-3334 |
 
   Given the following jobs exist:
-    | title   | fulltime | description | company      | creator          |
-    | SW dev  | true     | develop SW  | Widgets Inc. | carter@ymail.com |
-    | Trucker | true     | drive truck | Widgets Inc. | carter@ymail.com |
-    | Doctor  | true     | heal sick   | Widgets Inc. | carter@ymail.com |
-    | Clerk   | true     | service     | Widgets Inc. | carter@ymail.com |
-    | Mime    | true     | freeze      | Widgets Inc. | carter@ymail.com |
+    | title   | description | company      | creator          |
+    | SW dev  | develop SW  | Widgets Inc. | carter@ymail.com |
+    | Trucker | drive truck | Widgets Inc. | carter@ymail.com |
+    | Doctor  | heal sick   | Widgets Inc. | carter@ymail.com |
+    | Clerk   | service     | Widgets Inc. | carter@ymail.com |
+    | Mime    | freeze      | Widgets Inc. | carter@ymail.com |
 
   Given the following job applications exist:
 

--- a/features/jobs.feature
+++ b/features/jobs.feature
@@ -22,8 +22,8 @@ Background: adding job to database
   | Widgets Inc. | CC    | Jane       | Smith     | jane@ymail.com | qwerty123 | 555-222-3334 |
 
   Given the following jobs exist:
-  | title         | company_job_id  | fulltime | description | company      | creator          |
-  | software dev  | KRK01K          | true     | internship  | Widgets Inc. | jane@ymail.com |
+  | title         | company_job_id  | description | company      | creator          |
+  | software dev  | KRK01K          | internship  | Widgets Inc. | jane@ymail.com |
 
   Given the following company addresses exist:
   | company      | street       | city    | state    | zipcode |

--- a/features/manage_job_status.feature
+++ b/features/manage_job_status.feature
@@ -29,10 +29,10 @@ Background: data is added to database
     | John       | Seeker    | john@mail.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
 
   Given the following jobs exist:
-    | title        | company_job_id | fulltime | description | company      | creator        | status  |
-    | hr assistant | KRK01K         | true     | internship  | Widgets Inc. | carter@ymail.com | revoked |
-    | hr manager   | KRK02K         | true     | internship  | Widgets Inc. | carter@ymail.com | active  |
-    | hr associate | KRK03K         | true     | internship  | Widgets Inc. | carter@ymail.com | active  |
+    | title        | company_job_id | description | company      | creator        | status  |
+    | hr assistant | KRK01K         | internship  | Widgets Inc. | carter@ymail.com | revoked |
+    | hr manager   | KRK02K         | internship  | Widgets Inc. | carter@ymail.com | active  |
+    | hr associate | KRK03K         | internship  | Widgets Inc. | carter@ymail.com | active  |
 
   @javascript
   Scenario: company person revoke a job

--- a/features/match_job_and_resumes.feature
+++ b/features/match_job_and_resumes.feature
@@ -41,9 +41,9 @@ Feature: Match a Job to a Job Seeker's Résumé
      | Widgets Inc. | CA    | John       | Smith     | carter@ymail.com | qwerty123 | 555-222-3334 |
 
     Given the following jobs exist:
-     | title            | company_job_id| fulltime | description| company      | creator        |
-     | ruby developer   | KRK01         | true     | internship | Widgets Inc. | carter@ymail.com |
-     | java developer   | KRK02         | true     | internship | Widgets Inc. | carter@ymail.com |
+     | title            | company_job_id| description| company      | creator        |
+     | ruby developer   | KRK01         | internship | Widgets Inc. | carter@ymail.com |
+     | java developer   | KRK02         | internship | Widgets Inc. | carter@ymail.com |
 
     Given the following job applications exist:
      | job title      | job seeker            |

--- a/features/match_job_to_jds_job_seekers.feature
+++ b/features/match_job_to_jds_job_seekers.feature
@@ -40,8 +40,8 @@ Background: seed data added to database and log in as job developer
     | Hammer Inc.  | CA    | Tom        | Hammer    | ca@hammer.com    | qwerty123 | 555-222-4445 |
 
   Given the following jobs exist:
-    | title            | company_job_id  | fulltime | description                 |  company      | creator        |
-    | ruby developer   | KRK01K          | true     | internship position with pay| Hammer Inc. | ca@hammer.com |
+    | title            | company_job_id  | description                 |  company      | creator        |
+    | ruby developer   | KRK01K          | internship position with pay| Hammer Inc. | ca@hammer.com |
 
   @javascript
   Scenario: Valid selection of job seekers

--- a/features/match_jobs_to_job_seeker.feature
+++ b/features/match_jobs_to_job_seeker.feature
@@ -33,10 +33,10 @@ Given the following companies exist:
  | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@ymail.com   | corp@ymail.com | 12-3456789 | active |
 
 Given the following jobs exist:
- | title            | company_job_id  | fulltime | description| company      |
- | ruby developer   | KRK01K          | true     | internship | Widgets Inc. |
- | c++ developer    | KRK02K          | true     | internship | Widgets Inc. |
- | erlang developer | KRK03K          | true     | internship | Widgets Inc. |
+ | title            | company_job_id  | description| company      |
+ | ruby developer   | KRK01K          | internship | Widgets Inc. |
+ | c++ developer    | KRK02K          | internship | Widgets Inc. |
+ | erlang developer | KRK03K          | internship | Widgets Inc. |
 
 @javascript
 Scenario: Access job seeker job matching page

--- a/features/process_job_application.feature
+++ b/features/process_job_application.feature
@@ -32,9 +32,9 @@ Background: data is added to database
     | june@ymail.com | dave@metplus.org | JD   |
 
   Given the following jobs exist:
-    | title        | company_job_id | fulltime | description | company      | creator          |
-    | hr manager   | KRK02K         | true     | internship  | Widgets Inc. | cane@ymail.com |
-    | hr assistant | KRK01K       | true     | internship  | Widgets Inc. | cane@ymail.com |
+    | title        | company_job_id | description | company      | creator          |
+    | hr manager   | KRK02K         | internship  | Widgets Inc. | cane@ymail.com |
+    | hr assistant | KRK01K         | internship  | Widgets Inc. | cane@ymail.com |
 
   Given the following job applications exist:
     | job title      | job seeker    | status       |
@@ -52,7 +52,7 @@ Background: data is added to database
     Then I process "jane@ymail.com" application for "hr manager"
     And I should see an "process" confirmation
     Then I click the "Process" confirmation
-    And I wait 1 second 
+    And I wait 1 second
     And I should see "jane@ymail.com" application for "hr manager" changes to Processing
 
   @javascript

--- a/features/reject_job_application.feature
+++ b/features/reject_job_application.feature
@@ -32,14 +32,14 @@ Feature: Reject a job application
       | june@mail.com | dave@metplus.org | JD   |
 
     Given the following jobs exist:
-      | title        | company_job_id | fulltime | description | company      | creator          |
-      | hr manager   | KRK02K         | true     | internship  | Widgets Inc. | cane@ymail.com |
+      | title        | company_job_id | description | company      | creator          |
+      | hr manager   | KRK02K         | internship  | Widgets Inc. | cane@ymail.com |
 
     Given the following job applications exist:
-      | job title 	 | job seeker 	 | status 			|
-      | hr manager	 | john@mail.com | active 			|
-      | hr manager	 | jane@mail.com | active 			|
-      | hr manager	 | june@mail.com | active 			|
+      | job title    | job seeker    | status       |
+      | hr manager   | john@mail.com | active       |
+      | hr manager   | jane@mail.com | active       |
+      | hr manager   | june@mail.com | active       |
 
   @javascript
   Scenario: company contact reject a job application

--- a/features/view_job_application.feature
+++ b/features/view_job_application.feature
@@ -1,35 +1,35 @@
 Feature: View job application status
 
-	As a job seeker person
-	I want to view my job application status
+  As a job seeker person
+  I want to view my job application status
 
 Background: data is added to database
 
-	Given the default settings are present
+  Given the default settings are present
 
   Given the following companies exist:
     | agency  | name         | website     | phone        | email            | job_email        | ein        | status |
     | MetPlus | Widgets Inc. | widgets.com | 555-222-3333 | corp@ymail.com | corp@ymail.com | 12-3456789 | active |
 
   Given the following company people exist:
-  	| company      | role  | first_name | last_name | email            | password  | phone        |
-  	| Widgets Inc. | CA    | Cane       | Daniel    | cane@ymail.com | qwerty123 | 555-222-3334 |
+    | company      | role  | first_name | last_name | email            | password  | phone        |
+    | Widgets Inc. | CA    | Cane       | Daniel    | cane@ymail.com | qwerty123 | 555-222-3334 |
 
   Given the following jobseekers exist:
-  	| first_name | last_name | email         | phone        | password  | password_confirmation | year_of_birth | job_seeker_status  |
-  	| John       | Seeker    | john@mail.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
-  	| July       | Seeker    | july@mail.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+    | first_name | last_name | email         | phone        | password  | password_confirmation | year_of_birth | job_seeker_status  |
+    | John       | Seeker    | john@mail.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
+    | July       | Seeker    | july@mail.com | 345-890-7890 | qwerty123 | qwerty123             | 1990          | Unemployed Seeking |
 
   Given the following jobs exist:
-    | title        | company_job_id | fulltime | description | company      | creator        | status  |
-    | hr assistant | KRK01K         | true     | internship  | Widgets Inc. | cane@ymail.com | filled  |
-    | hr associate | KRK02K         | true     | internship  | Widgets Inc. | cane@ymail.com | filled  |
+    | title        | company_job_id | description | company      | creator        | status  |
+    | hr assistant | KRK01K         | internship  | Widgets Inc. | cane@ymail.com | filled  |
+    | hr associate | KRK02K         | internship  | Widgets Inc. | cane@ymail.com | filled  |
 
-	Given the following job applications exist:
-		| job title 	 | job seeker 	 | status 			|
-		| hr assistant | july@mail.com | accepted 		|
-		| hr associate | july@mail.com | not_accepted |
-		| hr associate | john@mail.com | accepted     |
+  Given the following job applications exist:
+    | job title    | job seeker    | status       |
+    | hr assistant | july@mail.com | accepted     |
+    | hr associate | july@mail.com | not_accepted |
+    | hr associate | john@mail.com | accepted     |
 
   @javascript
   Scenario: Successful and unsuccessful application for job seeker

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe JobsController, type: :controller do
   let!(:question) { FactoryGirl.create(:question) }
 
   let!(:valid_params) do
-    { title: 'Ruby on Rails', fulltime: true, description: 'passionate',
+    { title: 'Ruby on Rails', description: 'passionate',
       company_id: bosh.id, address_id: bosh_mich.id, shift: 'Evening',
       company_job_id: 'WERRR123',
       job_skills_attributes: { '0' => { skill_id: skill.id,

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     company_person {FactoryGirl.create(:company_person, company: company)}
     address
     company_job_id "KRKE12"
-    fulltime true
     status :active
   end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe Job, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :description }
     it { is_expected.to have_db_column :company_job_id }
-    it { is_expected.to have_db_column :fulltime }
     it { is_expected.to have_db_column :company_id }
     it { is_expected.to have_db_column :company_person_id }
     it { is_expected.to have_db_column :address_id }
@@ -72,8 +71,6 @@ RSpec.describe Job, type: :model do
     it { is_expected.to validate_length_of(:description).is_at_most(10_000) }
     it { is_expected.to validate_presence_of :company_job_id }
     it { is_expected.to validate_numericality_of :years_of_experience }
-    it { should allow_value('', nil).for(:fulltime).on(:update) }
-    it { should allow_value('', nil).for(:fulltime).on(:create) }
     it { should allow_value('', nil).for(:years_of_experience).on(:update) }
     it { should allow_value('', nil).for(:years_of_experience).on(:create) }
     it { should_not allow_value(21).for(:years_of_experience) }


### PR DESCRIPTION
Fixes https://github.com/AgileVentures/MetPlus_tracker/issues/664

Removes `fulltime` attribute from `jobs` table and `fulltime` reference in the whole codebase.