### PR TITLE
WIP: Remove act as

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ gem 'pusher'
 
 gem 'js_cookie_rails'
 
-gem 'active_record-acts_as'
-
 gem 'delayed_job_active_record'
 
 gem 'json'

--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,8 @@ end
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 
-gem 'devise',           '~> 3.5.2'
-gem 'devise_invitable', '~> 1.5.2'
+gem 'devise',           '~> 4.4.1'
+gem 'devise_invitable', '~> 1.7.3'
 
 gem 'figaro'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,9 +27,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_record-acts_as (1.0.7)
-      activerecord (~> 4, >= 4.1.2)
-      activesupport (~> 4)
     activejob (4.2.10)
       activesupport (= 4.2.10)
       globalid (>= 0.3.0)
@@ -352,7 +349,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_record-acts_as
   airbrake (~> 7.1)
   bcrypt (~> 3.1.7)
   bootstrap-will_paginate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,16 +99,15 @@ GEM
     delayed_job_active_record (4.1.0)
       activerecord (>= 3.0, < 5)
       delayed_job (>= 3.0, < 5)
-    devise (3.5.3)
+    devise (4.4.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 5.2)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
-    devise_invitable (1.5.5)
-      actionmailer (>= 3.2.6, < 5)
-      devise (>= 3.2.0)
+    devise_invitable (1.7.3)
+      actionmailer (>= 4.1.0)
+      devise (>= 4.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20160310)
@@ -254,8 +253,9 @@ GEM
       ffi (>= 0.5.0, < 2)
     rdoc (4.2.1)
       json (~> 1.4)
-    responders (2.1.1)
-      railties (>= 4.2.0, < 5.1)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -327,7 +327,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.2)
     uniform_notifier (1.10.0)
-    warden (1.2.4)
+    warden (1.2.7)
       rack (>= 1.0)
     web-console (2.2.1)
       activemodel (>= 4.0)
@@ -360,8 +360,8 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   delayed_job_active_record
-  devise (~> 3.5.2)
-  devise_invitable (~> 1.5.2)
+  devise (~> 4.4.1)
+  devise_invitable (~> 1.7.3)
   email_spec
   factory_bot_rails
   faker

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
 
     def pets_user
       return nil unless current_user
-      current_user.actable || current_user
+      current_user.pets_user || current_user
     end
 
     def store_current_location

--- a/app/controllers/people_invitations_controller.rb
+++ b/app/controllers/people_invitations_controller.rb
@@ -21,7 +21,7 @@ class PeopleInvitationsController < Devise::InvitationsController
   def invite_resource(&block)
     user = resource_class.invite!(invite_params, current_inviter, &block)
     if user.errors.empty?
-      if (person = user.actable)
+      if (person = user.pets_user)
         # If a person is already associated with this user, this means that
         # another invitation is being sent to that previously-invited person.
         redirect_path = (person.class == AgencyPerson ?
@@ -56,7 +56,7 @@ class PeopleInvitationsController < Devise::InvitationsController
   # should return an instance of resource class (User)
   def accept_resource
     user = resource_class.accept_invitation!(update_resource_params)
-    case (person = user.actable)
+    case (person = user.pets_user)
     when AgencyPerson
       person.active
       person.save

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -13,8 +13,8 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # GET /resource/confirmation?confirmation_token=abcdef
   def show
     super do |user|
-      if user.errors.empty? && user.actable_type == 'JobSeeker'
-        person = user.actable
+      if user.errors.empty? && user.pets_user.is_job_seeker?
+        person = user.pets_user
         Event.create(:JS_REGISTER, person)
       else
         # Override normal handling if the user's email address has already been

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,11 +14,11 @@ class Users::SessionsController < Devise::SessionsController
       if current_user.respond_to?(:remember_me) && current_user.remember_me
         cookies[:user_id]     = { value: current_user.id,
                                 expires: 1.year.from_now }
-        cookies[:person_type] = { value: current_user.actable_type,
+        cookies[:person_type] = { value: current_user.user_type,
                                 expires: 1.year.from_now }
       else
         cookies[:user_id]     = current_user.id
-        cookies[:person_type] = current_user.actable_type
+        cookies[:person_type] = current_user.user_type
       end
     end
   end

--- a/app/helpers/agency_admin_helper.rb
+++ b/app/helpers/agency_admin_helper.rb
@@ -1,7 +1,7 @@
 module AgencyAdminHelper
   def current_user_agency_admin?
     return false unless user_signed_in?
-    return false unless ((person = current_user.actable).is_a? AgencyPerson)
+    return false unless ((person = current_user.pets_user).is_a? AgencyPerson)
     person.agency_roles.pluck(:role).include? AgencyRole::ROLE[:AA]
   end
 

--- a/app/models/act_as_user.rb
+++ b/app/models/act_as_user.rb
@@ -5,25 +5,34 @@ module ActAsUser
   end
 
   def method_missing(name, *args, &block)
-    @user = User.new if @user.nil?    
+    self.user = User.new if self.user.nil?    
     begin
       super
     rescue NoMethodError
-      @user.send(name, *args, &block)
+      self.user.send(name, *args, &block)
     end 
   end
 
   def assign_attributes(new_attributes)
-    @user = User.new if @user.nil?
+    self.user = User.new if self.user.nil?
     model_attributes = new_attributes.select do |key, value|
       has_attribute? key
     end
     user_model_attributes = new_attributes.select do |key, value|
-      @user.has_attribute? key
+      self.user.has_attribute? key
     end
     super(model_attributes)
-    @user = User.new if user.nil?
-    @user.assign_attributes(user_model_attributes)
+    self.user = User.new if self.user.nil?
+    self.user.assign_attributes(user_model_attributes)
+  end
+
+  def is_a?(clazz)
+    return true if clazz == User
+    super(clazz)
+  end
+
+  def user_type
+    self.class.name
   end
   
   module ClassMethods

--- a/app/models/act_as_user.rb
+++ b/app/models/act_as_user.rb
@@ -15,6 +15,7 @@ module ActAsUser
 
   def assign_attributes(new_attributes)
     self.user = User.new if self.user.nil?
+    password = new_attributes.delete('password')
     model_attributes = new_attributes.select do |key, value|
       has_attribute? key
     end
@@ -22,8 +23,8 @@ module ActAsUser
       self.user.has_attribute? key
     end
     super(model_attributes)
-    self.user = User.new if self.user.nil?
     self.user.assign_attributes(user_model_attributes)
+    self.password = password
   end
 
   def is_a?(clazz)

--- a/app/models/act_as_user.rb
+++ b/app/models/act_as_user.rb
@@ -1,0 +1,38 @@
+module ActAsUser
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  def method_missing(name, *args, &block)
+    @user = User.new if @user.nil?    
+    begin
+      super
+    rescue NoMethodError
+      @user.send(name, *args, &block)
+    end 
+  end
+
+  def assign_attributes(new_attributes)
+    @user = User.new if @user.nil?
+    model_attributes = new_attributes.select do |key, value|
+      has_attribute? key
+    end
+    user_model_attributes = new_attributes.select do |key, value|
+      @user.has_attribute? key
+    end
+    super(model_attributes)
+    @user = User.new if user.nil?
+    @user.assign_attributes(user_model_attributes)
+  end
+  
+  module ClassMethods
+    def method_missing(name, *args, &block)
+      begin
+        super
+      rescue NoMethodError
+        User.send(name, *args, &block)
+      end
+    end
+  end
+end

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -16,8 +16,8 @@ class Agency < ActiveRecord::Base
   end
 
   def self.this_agency(user)
-    return nil unless user.actable.is_a? AgencyPerson
-    user.actable.agency
+    return nil unless user.pets_user.is_a? AgencyPerson
+    user.pets_user.agency
   end
 
   def agency_people_on_role role

--- a/app/models/agency_person.rb
+++ b/app/models/agency_person.rb
@@ -1,6 +1,8 @@
 class AgencyPerson < ActiveRecord::Base
-  acts_as :user
 
+  include ActAsUser
+
+  belongs_to :user
 
   belongs_to :agency
   belongs_to :branch

--- a/app/models/company_person.rb
+++ b/app/models/company_person.rb
@@ -1,5 +1,7 @@
 class CompanyPerson < ActiveRecord::Base
-  acts_as :user
+  include ActAsUser
+  
+  belongs_to :user
   belongs_to :company
   belongs_to :address
   has_and_belongs_to_many :company_roles,

--- a/app/models/job_seeker.rb
+++ b/app/models/job_seeker.rb
@@ -1,4 +1,6 @@
 class JobSeeker < ActiveRecord::Base
+  include ActAsUser
+
   belongs_to :user
   has_many :resumes, dependent: :destroy
 
@@ -67,13 +69,13 @@ class JobSeeker < ActiveRecord::Base
 
   def self.job_seekers_without_job_developer
     where.not(id: AgencyRelation.in_role_of(:JD).pluck(:job_seeker_id))
-         .includes(:job_seeker_status, :job_applications)
+         .includes(:job_seeker_status, :job_applications, :user)
          .order('users.last_name')
   end
 
   def self.job_seekers_without_case_manager
     where.not(id: AgencyRelation.in_role_of(:CM).pluck(:job_seeker_id))
-         .includes(:job_seeker_status, :job_applications)
+         .includes(:job_seeker_status, :job_applications, :user)
          .order('users.last_name')
   end
 
@@ -120,21 +122,5 @@ class JobSeeker < ActiveRecord::Base
       return ap_relation if ap_relation
     end
     nil # return nil if no agency person found for that role
-  end
-
-  def method_missing(name, *args, &block)
-    begin
-      super
-    rescue NoMethodError
-      user.send(name, *args, &block)
-    end 
-  end
-
-  def self.method_missing(name, *args, &block)
-    begin
-      super
-    rescue NoMethodError
-      User.send(name, *args, &block)
-    end
   end
 end

--- a/app/models/job_seeker.rb
+++ b/app/models/job_seeker.rb
@@ -1,5 +1,5 @@
 class JobSeeker < ActiveRecord::Base
-  acts_as :user
+  belongs_to :user
   has_many :resumes, dependent: :destroy
 
   has_one :address, as: :location, dependent: :destroy
@@ -120,5 +120,21 @@ class JobSeeker < ActiveRecord::Base
       return ap_relation if ap_relation
     end
     nil # return nil if no agency person found for that role
+  end
+
+  def method_missing(name, *args, &block)
+    begin
+      super
+    rescue NoMethodError
+      user.send(name, *args, &block)
+    end 
+  end
+
+  def self.method_missing(name, *args, &block)
+    begin
+      super
+    rescue NoMethodError
+      User.send(name, *args, &block)
+    end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -42,11 +42,11 @@ class Task < ActiveRecord::Base
   }
   scope :agency_tasks, lambda { |user|
     where('(owner_agency_id = ? or owner_user_id in (?))',
-          user.agency.id, user.agency.agency_people.map { |a| a.acting_as.id }.map)
+          user.agency.id, user.agency.agency_people.map { |a| a.user.id }.map)
   }
   scope :company_tasks, lambda { |user|
     where('(owner_company_id = ? or owner_user_id in (?))',
-          user.company.id, user.company.company_people.map { |a| a.acting_as.id }.map)
+          user.company.id, user.company.company_people.map { |a| a.user.id }.map)
   }
 
   scope :job_seeker_target, ->(user) { where('user_id = ?', user.pets_user.user.id) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,12 +10,16 @@ class User < ActiveRecord::Base
    validates   :phone, :phone => true
    validates   :email, :email => true
 
+   has_one :job_seeker
+   has_one :agency_person
+   has_one :company_person
+
    def self.is_job_seeker?(user)
-     user.actable_type == 'JobSeeker'
+     user.job_seeker != nil
    end
 
    def self.is_job_developer?(user)
-      return false unless user.actable_type == "AgencyPerson"
+      return false unless user.agency_person != nil
       user.actable.agency_roles.pluck(:role).include? AgencyRole::ROLE[:JD]
    end
 
@@ -61,7 +65,9 @@ class User < ActiveRecord::Base
   end
 
   def pets_user
-    self.try(:actable).nil? ? self : self.actable
+    return job_seeker if job_seeker != nil
+    return agency_person if agency_person != nil
+    return company_person if company_person != nil
   end
 
   def is_job_seeker?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :confirmable,
          :validatable
-   actable
+
    validates_presence_of :first_name
    validates_presence_of :last_name
    validates   :phone, :phone => true
@@ -20,17 +20,17 @@ class User < ActiveRecord::Base
 
    def self.is_job_developer?(user)
       return false unless user.agency_person != nil
-      user.actable.agency_roles.pluck(:role).include? AgencyRole::ROLE[:JD]
+      user.agency_person.agency_roles.pluck(:role).include? AgencyRole::ROLE[:JD]
    end
 
    def self.is_case_manager?(user)
-      return false unless user.actable_type == "AgencyPerson"
-      user.actable.agency_roles.pluck(:role).include? AgencyRole::ROLE[:CM]
+      return false unless user.agency_person != nil
+      user.agency_person.agency_roles.pluck(:role).include? AgencyRole::ROLE[:CM]
    end
 
     def self.is_agency_admin?(user)
-      return false unless user.actable_type == "AgencyPerson"
-      user.actable.agency_roles.pluck(:role).include? AgencyRole::ROLE[:AA]
+      return false unless user.agency_person != nil
+      user.agency_person.agency_roles.pluck(:role).include? AgencyRole::ROLE[:AA]
     end
 
     def self.is_agency_person?(user)
@@ -38,13 +38,13 @@ class User < ActiveRecord::Base
     end
 
     def self.is_company_admin?(user)
-      return false unless user.actable_type == "CompanyPerson"
-      user.actable.company_roles.pluck(:role).include? CompanyRole::ROLE[:CA]
+      return false unless user.company_person != nil
+      user.company_person.company_roles.pluck(:role).include? CompanyRole::ROLE[:CA]
     end
 
     def self.is_company_contact?(user)
-      return false unless user.actable_type == "CompanyPerson"
-      user.actable.company_roles.pluck(:role).include? CompanyRole::ROLE[:CC]
+      return false unless user.company_person != nil
+      user.company_person.company_roles.pluck(:role).include? CompanyRole::ROLE[:CC]
     end
 
     def self.is_company_person?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,12 @@ class User < ActiveRecord::Base
     return company_person if company_person != nil
   end
 
+  def user_type
+    return job_seeker.class.name if job_seeker != nil
+    return agency_person.class.name if agency_person != nil
+    return company_person.class.name if company_person != nil
+  end
+
   def is_job_seeker?
     false
   end
@@ -103,9 +109,9 @@ class User < ActiveRecord::Base
   end
 
   def inactive_message
-    if !approved? && actable.try(:company_pending?)
+    if !approved? && pets_user.try(:company_pending?)
       :signed_up_but_not_approved
-    elsif !approved? && actable.try(:company_denied?)
+    elsif !approved? && pets_user.try(:company_denied?)
       :not_approved
     else
       super

--- a/app/views/devise/mailer/invitation_instructions.html.haml
+++ b/app/views/devise/mailer/invitation_instructions.html.haml
@@ -1,7 +1,7 @@
 %p= t("devise.mailer.invitation_instructions.hello", first_name: @resource.first_name)
 
 %p
-  - if (inviter = @resource.invited_by.actable).class == AgencyPerson
+  - if (inviter = @resource.invited_by.pets_user).class == AgencyPerson
     = t("devise.mailer.invitation_instructions.admin_invited_you", org: inviter.agency.name)
     %br/
     %br/

--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -44,12 +44,12 @@
                 = ("<span class='caret'></span>").html_safe
               %ul.dropdown-menu{ 'aria-labelledby' => 'dd_menu' }
                 %li
-                  - if current_user.actable_type == 'JobSeeker'
-                    = link_to 'My Profile', my_profile_job_seeker_path(current_user.actable_id)
-                  - elsif current_user.actable_type == 'CompanyPerson'
-                    = link_to 'My Profile', my_profile_company_person_path(current_user.actable_id)
-                  - elsif current_user.actable_type == 'AgencyPerson'
-                    = link_to 'My Profile', my_profile_agency_person_path(current_user.actable_id)
+                  - if current_user.pets_user.is_job_seeker?
+                    = link_to 'My Profile', my_profile_job_seeker_path(current_user.pets_user.id)
+                  - elsif current_user.pets_user.is_company_person?
+                    = link_to 'My Profile', my_profile_company_person_path(current_user.pets_user.id)
+                  - elsif current_user.pets_user.is_a? AgencyPerson
+                    = link_to 'My Profile', my_profile_agency_person_path(current_user.pets_user.id)
                   - else
                     = link_to 'Edit Profile', edit_user_registration_path(current_user)
                 %li

--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -46,7 +46,7 @@
                 %li
                   - if current_user.pets_user.is_job_seeker?
                     = link_to 'My Profile', my_profile_job_seeker_path(current_user.pets_user.id)
-                  - elsif current_user.pets_user.is_company_person?
+                  - elsif User.is_company_person?(current_user.pets_user)
                     = link_to 'My Profile', my_profile_company_person_path(current_user.pets_user.id)
                   - elsif current_user.pets_user.is_a? AgencyPerson
                     = link_to 'My Profile', my_profile_agency_person_path(current_user.pets_user.id)

--- a/db/migrate/20151107120000_create_database.rb
+++ b/db/migrate/20151107120000_create_database.rb
@@ -18,7 +18,8 @@ class CreateDatabase < ActiveRecord::Migration
       t.string :first_name
       t.string :last_name
       t.string :phone
-      t.actable
+      t.integer :actable_id
+      t.string :actable_type
 
       ## Database authenticatable
       # t.string :email,              null: false, default: ""

--- a/db/migrate/20171215132729_remove_act_as.rb
+++ b/db/migrate/20171215132729_remove_act_as.rb
@@ -1,0 +1,25 @@
+class RemoveActAs < ActiveRecord::Migration
+  def change
+    add_column :job_seekers, :user_id, :integer
+    add_column :agency_people, :user_id, :integer
+    add_column :company_people, :user_id, :integer
+    User.all.each do |user|
+      pets_user = nil
+      if user.actable_type == 'JobSeeker'
+        pets_user = JobSeeker.find_by_id(user.actable_id)
+      elsif user.actable_type == 'AgencyPerson'
+        pets_user = AgencyPerson.find_by_id(user.actable_id)
+      elsif user.actable_type == 'CompanyPerson'
+        pets_user = CompanyPerson.find_by_id(user.actable_id)
+      end
+      pets_user.user_id = user.id
+      pets_user.save!
+    end
+    remove_column :users, :actable_id
+    remove_column :users, :actable_type
+    
+    add_foreign_key :job_seekers, :users
+    add_foreign_key :agency_people, :users
+    add_foreign_key :company_people, :users
+  end
+end

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -54,8 +54,8 @@ end
 
 Given(/^the following agency relations exist:$/) do |table|
   table.hashes.each do |hash|
-    job_seeker    = User.find_by_email(hash['job_seeker']).actable
-    agency_person = User.find_by_email(hash['agency_person']).actable
+    job_seeker    = User.find_by_email(hash['job_seeker']).pets_user
+    agency_person = User.find_by_email(hash['agency_person']).pets_user
     if hash['role'] == 'JD'
       job_seeker.assign_job_developer agency_person, agency_person.agency
     else
@@ -107,7 +107,6 @@ end
 Given(/^the following jobseeker(?:s?) exist:$/) do |table|
   table.hashes.each do |hash|
     hash.delete 'jobseeker'
-    hash['actable_type'] = 'JobSeeker'
     hash['password_confirmation'] = hash['password']
     hash['confirmed_at'] = Time.now
     seeker_status = hash.delete 'job_seeker_status'
@@ -224,7 +223,7 @@ end
 Given(/^the following job applications exist:$/) do |table|
   table.hashes.each do |hash|
     job = Job.find_by_title(hash['job title'])
-    job_seeker = User.find_by_email(hash['job seeker']).actable
+    job_seeker = User.find_by_email(hash['job seeker']).pets_user
 
     if hash[:status]
       FactoryBot.create(:job_application, job: job, job_seeker: job_seeker,

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -184,8 +184,7 @@ Given(/^the following jobs exist:$/) do |table|
     job = Job.new(hash.merge(company_job_id: 'JOBID'))
 
     job.company = Company.find_by_name company_name
-    job.company_person = User.find_by_email(creator_email).pets_user if
-      creator_email
+    job.company_person = User.find_by_email(creator_email).pets_user if creator_email
 
     unless city.blank?
       job.address = FactoryBot.create(:address,

--- a/features/step_definitions/job_applications_steps.rb
+++ b/features/step_definitions/job_applications_steps.rb
@@ -1,6 +1,6 @@
 And(/^I (accept|reject|process) "([^"]*)" application for "([^"]*)"$/) do |action, email, job|
   job = Job.find_by(title: job.to_s)
-  job_seeker = User.find_by_email(email).actable
+  job_seeker = User.find_by_email(email).pets_user
   @job_app = JobApplication.find_by(job: job, job_seeker: job_seeker)
   find("#applications-#{@job_app.id} ##{action}_link").click
 end
@@ -23,7 +23,7 @@ And(/^I\sshould\ssee\s"([^"]*)"\sactive\sapplications\s(for|by)\s
     job = Job.find_by(title: source.to_s)
     app_ids = JobApplication.select(:id).where(status: 'active', job: job)
   else
-    job_seeker = User.find_by_email(source).actable
+    job_seeker = User.find_by_email(source).pets_user
     app_ids = JobApplication.select(:id).where(status: 'active', job_seeker: job_seeker)
   end
   expect(app_ids.count).to eq count.to_i
@@ -32,7 +32,7 @@ end
 And(/I\sshould\ssee\s"([^"]*)"\sapplication\sfor\s"([^"]*)"\schanges\sto\s
   (accepted|not_accepted|Processing)$/x) do |email, job, state|
   job = Job.find_by(title: job.to_s)
-  job_seeker = User.find_by_email(email).actable
+  job_seeker = User.find_by_email(email).pets_user
   app = JobApplication.find_by(job_seeker: job_seeker, job: job)
   within("#applications-#{app.id}") { expect(page).to have_content(state) }
 end
@@ -58,7 +58,7 @@ Then(/^I should( not)? see(?: an)? "([^"]*)" link$/) do |not_see, action|
 end
 
 And(/^I should see "([^"]*)" application is listed (first|last)$/) do |email, position|
-  job_seeker = User.find_by_email(email).actable
+  job_seeker = User.find_by_email(email).pets_user
   within(".pagination-div > table > tbody > tr:#{position}-child") do
     expect(page).to have_content(job_seeker.first_name.to_s)
   end
@@ -71,7 +71,7 @@ end
 
 And(/^I\sshould\ssee\smy\s"([^"]*)"\sapplication\sfor\s"([^"]*)"\swas\s
   "([^"]*)"$/x) do |email, job_title, status|
-  job_seeker = User.find_by_email(email).actable
+  job_seeker = User.find_by_email(email).pets_user
   job = Job.find_by(title: job_title.to_s)
   job_app = JobApplication.find_by(job: job, job_seeker: job_seeker)
   expect(page.find("#applications-#{job_app.id}")).to have_content(status.to_s)
@@ -82,7 +82,7 @@ And(/^I should see "(?:[^"]*)" show status "([^"]*)"$/) do |status|
 end
 
 And(/^I return to my "([^"]*)" home page$/) do |email|
-  job_seeker = User.find_by_email(email).actable
+  job_seeker = User.find_by_email(email).pets_user
   role = job_seeker.class.to_s.underscore
   visit "/#{role}s/#{job_seeker.id}/home"
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -73,9 +73,9 @@ Then(/^I should be on the (.+) page$/) do |page_name|
 end
 
 Given(/I am on the JobSeeker Show page for "([^"]*)"$/) do |email|
-  visit job_seeker_path(User.find_by_email(email).actable_id)
+  visit job_seeker_path(User.find_by_email(email).pets_user.id)
 end
 
 Then(/^I press the Job Match button for '(.+)'$/) do |email|
-  find("#match-job-#{User.find_by_email(email).actable_id}").click
+  find("#match-job-#{User.find_by_email(email).pets_user.id}").click
 end

--- a/spec/controllers/agencies_controller_spec.rb
+++ b/spec/controllers/agencies_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AgenciesController, type: :controller do
   describe 'GET #edit' do
     context 'success' do
       before(:each) do
-        sign_in agency_admin
+        warden.set_user agency_admin
         get :edit, id: agency
       end
       it 'assigns agency for form' do
@@ -23,7 +23,7 @@ RSpec.describe AgenciesController, type: :controller do
     end
     context 'as Job Developer' do
       before(:each) do
-        sign_in job_developer
+        warden.set_user job_developer
         get :edit, id: agency
       end
       it 'redirect' do
@@ -39,7 +39,7 @@ RSpec.describe AgenciesController, type: :controller do
   describe 'PATCH #update' do
     context 'valid attributes' do
       before(:each) do
-        sign_in agency_admin
+        warden.set_user agency_admin
         patch :update, agency: FactoryBot.attributes_for(:agency),
                        id: agency
       end
@@ -60,7 +60,7 @@ RSpec.describe AgenciesController, type: :controller do
       render_views
 
       before(:each) do
-        sign_in agency_admin
+        warden.set_user agency_admin
         patch :update, agency: FactoryBot.attributes_for(
           :agency,
           phone: '',
@@ -83,11 +83,11 @@ RSpec.describe AgenciesController, type: :controller do
     context '.edit' do
       it 'authorizes agency_admin' do
         expect(subject).to_not receive(:user_not_authorized)
-        sign_in agency_admin
+        warden.set_user agency_admin
         get :edit, id: agency.id
       end
       it 'does not authorize non-admin user' do
-        sign_in job_developer
+        warden.set_user job_developer
         get :edit, id: agency.id
         expect(flash[:alert])
           .to eq "You are not authorized to edit #{agency.name} agency."
@@ -97,12 +97,12 @@ RSpec.describe AgenciesController, type: :controller do
     context '.update' do
       it 'authorizes agency_admin' do
         expect(subject).to_not receive(:user_not_authorized)
-        sign_in agency_admin
+        warden.set_user agency_admin
         patch :update, agency: FactoryBot.attributes_for(:agency),
                        id: agency
       end
       it 'does not authorize non-admin user' do
-        sign_in job_developer
+        warden.set_user job_developer
         patch :update, agency: FactoryBot.attributes_for(:agency),
                        id: agency
         expect(flash[:alert])

--- a/spec/controllers/agency_admin_controller_spec.rb
+++ b/spec/controllers/agency_admin_controller_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe AgencyAdminController, type: :controller do
 
     context 'non agency person attempts access' do
       it 'prevents non agency access' do
-        sign_in agency_admin
-        agency_admin.update_attribute(:actable_type, nil)
+        warden.set_user job_seeker
         get :home
         expect(flash[:notice])
           .to eq 'Current agency cannot be determined'

--- a/spec/controllers/agency_admin_controller_spec.rb
+++ b/spec/controllers/agency_admin_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AgencyAdminController, type: :controller do
   let!(:agency_admin) { FactoryBot.create(:agency_admin, agency: agency) }
   let(:case_manager)  { FactoryBot.create(:case_manager, agency: agency) }
   let(:job_developer) { FactoryBot.create(:job_developer, agency: agency) }
-  let(:job_seeker)    { FactoryBot.create(:job_seeker) }
+  let!(:job_seeker)    { FactoryBot.create(:job_seeker) }
   let(:job_categories) do
     cats = []
     cats << FactoryBot.create(:job_category, name: 'CAT1') <<
@@ -30,14 +30,19 @@ RSpec.describe AgencyAdminController, type: :controller do
     context 'non agency person attempts access' do
       it 'prevents non agency access' do
         warden.set_user job_seeker
+        # warden.set_user job_seeker
         get :home
         expect(flash[:notice])
           .to eq 'Current agency cannot be determined'
       end
+      after(:each) do
+        sign_out job_seeker
+      end
     end
+
     context 'controller actions and helper - home page' do
       before(:each) do
-        sign_in agency_admin
+        warden.set_user agency_admin
         get :home
       end
       it 'assigns agency for view' do
@@ -56,7 +61,7 @@ RSpec.describe AgencyAdminController, type: :controller do
 
     context 'controller actions and helper - job properties page' do
       before(:each) do
-        sign_in agency_admin
+        warden.set_user agency_admin
         get :job_properties
       end
       it 'assigns job_categories for view' do
@@ -79,7 +84,7 @@ RSpec.describe AgencyAdminController, type: :controller do
         cmp.agencies << agency
         cmp.save
       end
-      sign_in agency_admin
+      warden.set_user agency_admin
       get :home
     end
 
@@ -105,10 +110,11 @@ RSpec.describe AgencyAdminController, type: :controller do
 
   describe 'XHR GET #job_properties' do
     before(:each) do
+      JobCategory.delete_all
       25.times do |n|
         FactoryBot.create(:job_category, name: "CAT#{n}")
       end
-      sign_in agency_admin
+      warden.set_user agency_admin
       get :job_properties
     end
 
@@ -138,31 +144,31 @@ RSpec.describe AgencyAdminController, type: :controller do
     end
 
     it 'this agency - from agency admin' do
-      sign_in agency_admin
+      warden.set_user agency_admin
       expect(Agency.this_agency(subject.current_user)).to eq agency
     end
     it 'this agency - from case manager' do
-      sign_in case_manager
+      warden.set_user case_manager
       expect(Agency.this_agency(subject.current_user)).to eq agency
     end
     it 'this agency - from job developer' do
-      sign_in job_developer
+      warden.set_user job_developer
       expect(Agency.this_agency(subject.current_user)).to eq agency
     end
     it 'non-admin and non-agency returns nil' do
-      sign_in job_seeker
+      warden.set_user job_seeker
       expect(Agency.this_agency(job_seeker)).to eq nil
     end
     it 'agency admin - from agency admin' do
-      sign_in agency_admin
+      warden.set_user agency_admin
       expect(Agency.agency_admins(agency)).to eq [agency_admin]
     end
     it 'agency admin - from case manager' do
-      sign_in case_manager
+      warden.set_user case_manager
       expect(Agency.agency_admins(agency)).to eq [agency_admin]
     end
     it 'agency admin - from job developer' do
-      sign_in job_developer
+      warden.set_user job_developer
       expect(Agency.agency_admins(agency)).to eq [agency_admin]
     end
   end
@@ -171,11 +177,11 @@ RSpec.describe AgencyAdminController, type: :controller do
     context '.home' do
       it 'authorizes agency_admin' do
         expect(subject).to_not receive(:user_not_authorized)
-        sign_in agency_admin
+        warden.set_user agency_admin
         get :home
       end
       it 'does not authorize non-admin user' do
-        sign_in case_manager
+        warden.set_user case_manager
         get :home
         expect(flash[:alert])
           .to eq "You are not authorized to administer #{agency.name} agency."
@@ -185,11 +191,11 @@ RSpec.describe AgencyAdminController, type: :controller do
     context '.job_properties' do
       it 'authorizes agency_admin' do
         expect(subject).to_not receive(:user_not_authorized)
-        sign_in agency_admin
+        warden.set_user agency_admin
         expect { get :job_properties }.to_not raise_error
       end
       it 'does not authorize non-admin user' do
-        sign_in case_manager
+        warden.set_user case_manager
         get :job_properties
         expect(flash[:alert])
           .to eq "You are not authorized to administer #{agency.name} agency."

--- a/spec/controllers/agency_people_controller_spec.rb
+++ b/spec/controllers/agency_people_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
     before(:each) do
       adam.assign_job_developer(jd_person, agency)
       bob.assign_case_manager(cm_person, agency)
-      sign_in jd_person
+      warden.set_user jd_person
       get :home, id: jd_person
     end
 
@@ -38,7 +38,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
       before(:each) do
         adam.assign_job_developer(jd_person, agency)
         bob.assign_case_manager(cm_person, agency)
-        sign_in jd_person
+        warden.set_user jd_person
         get :home, id: jd_person
       end
 
@@ -55,7 +55,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
       before(:each) do
         adam.assign_job_developer(jd_person, agency)
         bob.assign_case_manager(cm_person, agency)
-        sign_in cm_person
+        warden.set_user cm_person
         get :home, id: cm_person
       end
 
@@ -71,7 +71,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
   describe 'GET #show' do
     before(:each) do
-      sign_in jd_person
+      warden.set_user jd_person
       get :show, id: jd_person.id
     end
 
@@ -88,7 +88,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
   describe 'GET #edit' do
     before(:each) do
-      sign_in aa_person
+      warden.set_user aa_person
       get :edit, id: jd_person
     end
 
@@ -122,7 +122,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
         person_hash[:agency_role_ids] = [aa_role.id.to_s]
         person_hash[:as_jd_job_seeker_ids] = []
         person_hash[:as_cm_job_seeker_ids] = []
-        sign_in aa_person
+        warden.set_user aa_person
         patch :update, id: aa_person,
                        agency_person: person_hash
       end
@@ -150,7 +150,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
         person_hash[:agency_role_ids] = []
         person_hash[:as_jd_job_seeker_ids] = []
         person_hash[:as_cm_job_seeker_ids] = []
-        sign_in aa_person
+        warden.set_user aa_person
         patch :update, id: aa_person, agency_person: person_hash
       end
 
@@ -170,7 +170,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
         person_hash = aa_person.attributes.merge(aa_person.user.attributes)
         person_hash[:as_jd_job_seeker_ids] = [job_seeker.id]
         person_hash[:as_cm_job_seeker_ids] = []
-        sign_in aa_person
+        warden.set_user aa_person
 
         allow(assign_agency_person_mock)
           .to receive(:call)
@@ -197,7 +197,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
         person_hash = aa_person.attributes.merge(aa_person.user.attributes)
         person_hash[:as_jd_job_seeker_ids] = []
         person_hash[:as_cm_job_seeker_ids] = [job_seeker.id]
-        sign_in aa_person
+        warden.set_user aa_person
 
         allow(assign_agency_person_mock)
           .to receive(:call)
@@ -230,7 +230,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
       before(:each) do
         allow(Pusher).to receive(:trigger)
-        sign_in aa_person
+        warden.set_user aa_person
         patch :update, id: jd_person, agency_person: person_hash
       end
 
@@ -250,7 +250,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
       end
 
       before(:each) do
-        sign_in aa_person
+        warden.set_user aa_person
         patch :update, id: cm_person, agency_person: person_hash
       end
 
@@ -276,7 +276,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
     context 'assign job developer to job seeker' do
       before do |example|
         allow(Pusher).to receive(:trigger)
-        sign_in aa_person
+        warden.set_user aa_person
         unless example.metadata[:skip_before]
           xhr :patch, :assign_job_seeker, id: jd_person.id,
                                           job_seeker_id: adam.id,
@@ -317,7 +317,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
     context 'assign case manager to job seeker' do
       before do |example|
         allow(Pusher).to receive(:trigger)
-        sign_in aa_person
+        warden.set_user aa_person
         unless example.metadata[:skip_before]
           xhr :patch, :assign_job_seeker, id: cm_person.id,
                                           job_seeker_id: adam.id,
@@ -360,7 +360,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
           .to receive(:call)
           .and_raise(JobSeekers::AssignAgencyPerson::InvalidRole)
 
-        sign_in aa_person
+        warden.set_user aa_person
         xhr :patch, :assign_job_seeker, id: cm_person.id,
                                         job_seeker_id: adam.id,
                                         agency_role: 'AA'
@@ -372,7 +372,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
   describe 'GET #destroy' do
     before(:each) do
-      sign_in aa_person
+      warden.set_user aa_person
       get :destroy, id: cm_person.id
     end
 
@@ -388,7 +388,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
   describe 'GET #edit_profile' do
     before(:each) do
-      sign_in jd_person
+      warden.set_user jd_person
       get :edit_profile, id: jd_person
     end
 
@@ -409,7 +409,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
     context 'valid attributes' do
       before(:each) do
         person_hash = aa_person.attributes.merge(aa_person.user.attributes)
-        sign_in aa_person
+        warden.set_user aa_person
         patch :update_profile, id: aa_person,
                                agency_person: person_hash
       end
@@ -430,7 +430,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
     context 'valid attributes without password change' do
       before(:each) do
         @password = aa_person.encrypted_password
-        sign_in aa_person
+        warden.set_user aa_person
         patch :update_profile,
               agency_person:
                 FactoryBot.attributes_for(:agency_person,
@@ -473,7 +473,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
   describe 'GET #list_js_cm' do
     before(:each) do
-      sign_in cm_person
+      warden.set_user cm_person
       adam.assign_case_manager(cm_person, cm_person.agency)
       xhr :get, :list_js_cm, id: cm_person.id,
                              people_type: 'jobseeker-cm'
@@ -494,7 +494,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
 
   describe 'GET #list_js_jd' do
     before(:each) do
-      sign_in jd_person
+      warden.set_user jd_person
       adam.assign_job_developer(jd_person, jd_person.agency)
       xhr :get, :list_js_jd, id: jd_person.id,
                              people_type: 'jobseeker-jd'
@@ -535,7 +535,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
         @js4.assign_job_developer(@job_developer, agency)
         @js4.assign_case_manager(@jd_cm, agency)
 
-        sign_in @jd_cm
+        warden.set_user @jd_cm
       end
 
       it 'returns http success' do
@@ -591,7 +591,7 @@ RSpec.describe AgencyPeopleController, type: :controller do
         @job_developer1 = FactoryBot.create(:job_developer, agency: agency)
         @js1 = FactoryBot.create(:job_seeker)
         @js2 = FactoryBot.create(:job_seeker)
-        sign_in @job_developer1
+        warden.set_user @job_developer1
         xhr :get, :my_js_as_jd, id: @job_developer1.id, format: :json
       end
 

--- a/spec/controllers/applcation_controller_spec.rb
+++ b/spec/controllers/applcation_controller_spec.rb
@@ -5,19 +5,19 @@ RSpec.describe ApplicationController, type: :controller do
   let!(:company_admin) { FactoryBot.create(:company_admin) }
   let!(:job_seeker) { FactoryBot.create(:job_seeker) }
 
-  describe 'after_sign_in_path_for(resource) method' do
+  describe 'after_warden.set_user_path_for(resource) method' do
     it 'redirects to the job seeker home path' do
-      expect(controller.after_sign_in_path_for(job_seeker))
+      expect(controller.after_warden.set_user_path_for(job_seeker))
         .to eq home_job_seeker_path(job_seeker)
     end
 
     it 'redirects to the company person home path' do
-      expect(controller.after_sign_in_path_for(company_admin))
+      expect(controller.after_warden.set_user_path_for(company_admin))
         .to eq home_company_person_path(company_admin)
     end
 
     it 'redirects to the agency admin home path' do
-      expect(controller.after_sign_in_path_for(agency_admin))
+      expect(controller.after_warden.set_user_path_for(agency_admin))
         .to eq home_agency_person_path(agency_admin)
     end
   end

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe BranchesController, type: :controller do
   let(:js)      { FactoryBot.create(:job_seeker) }
   describe 'GET #show' do
     before(:each) do
-      sign_in admin
+      warden.set_user admin
       get :show, id: branch.id
     end
     it 'assigns @branch for view' do
@@ -82,7 +82,7 @@ RSpec.describe BranchesController, type: :controller do
     end
     context 'valid attributes' do
       before(:each) do
-        sign_in admin
+        warden.set_user admin
         post :create,
              agency_id: agency,
              branch: FactoryBot.attributes_for(:branch)
@@ -103,7 +103,7 @@ RSpec.describe BranchesController, type: :controller do
     context 'invalid attributes' do
       render_views
       before(:each) do
-        sign_in admin
+        warden.set_user admin
         branch2.address.assign_attributes(zipcode: '123456')
         branch2.valid?
         branch_hash = FactoryBot.attributes_for(:branch, code: branch1.code)
@@ -127,7 +127,7 @@ RSpec.describe BranchesController, type: :controller do
   end
   describe 'GET #new' do
     before(:each) do
-      sign_in admin
+      warden.set_user admin
       get :new, agency_id: agency
     end
     it 'assigns @agency for branch creation' do
@@ -140,7 +140,7 @@ RSpec.describe BranchesController, type: :controller do
   end
   describe 'GET #edit' do
     before(:each) do
-      sign_in admin
+      warden.set_user admin
       get :edit, id: branch.id
     end
     it 'assigns @branch for form' do
@@ -158,7 +158,7 @@ RSpec.describe BranchesController, type: :controller do
     let(:branch2)  { FactoryBot.create(:branch, agency: agency) }
     context 'valid attributes' do
       before(:each) do
-        sign_in admin
+        warden.set_user admin
         patch :update, branch: FactoryBot.attributes_for(:branch),
                        id: branch1.id
       end
@@ -178,7 +178,7 @@ RSpec.describe BranchesController, type: :controller do
     context 'invalid attributes' do
       render_views
       before(:each) do
-        sign_in admin
+        warden.set_user admin
         branch2.assign_attributes(code: branch1.code)
         branch2.address.assign_attributes(zipcode: '123456')
         branch2.valid?
@@ -201,7 +201,7 @@ RSpec.describe BranchesController, type: :controller do
   end
   describe 'DELETE #destroy' do
     before(:each) do
-      sign_in admin
+      warden.set_user admin
       delete :destroy, id: branch.id
     end
     it 'sets flash message' do

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe CompaniesController, type: :controller do
 
   describe 'GET #show' do
     before(:each) do
-      sign_in company_admin
+      warden.set_user company_admin
       get :show, id: company
     end
     it 'assigns @company for view' do
@@ -71,7 +71,7 @@ RSpec.describe CompaniesController, type: :controller do
 
   describe 'GET #edit' do
     before(:each) do
-      sign_in company_admin
+      warden.set_user company_admin
       get :edit, id: company
     end
     it 'assigns @company for form' do
@@ -90,7 +90,7 @@ RSpec.describe CompaniesController, type: :controller do
       before(:each) do
         stub_cruncher_authenticate
         stub_cruncher_job_create
-        sign_in admin
+        warden.set_user admin
         delete :destroy, id: company_with_jobs
       end
 
@@ -109,7 +109,7 @@ RSpec.describe CompaniesController, type: :controller do
 
     context 'company with no jobs' do
       before(:each) do
-        sign_in admin
+        warden.set_user admin
         delete :destroy, id: company
       end
 
@@ -134,7 +134,7 @@ RSpec.describe CompaniesController, type: :controller do
     let!(:cp4) { FactoryBot.create(:company_contact, company: company) }
 
     before(:each) do
-      sign_in cp1
+      warden.set_user cp1
       xhr :get, :list_people, id: company
     end
     it 'assigns @people to collection of all company people' do
@@ -155,7 +155,7 @@ RSpec.describe CompaniesController, type: :controller do
     end
 
     before(:each) do
-      sign_in company_admin
+      warden.set_user company_admin
     end
 
     context 'valid attributes' do

--- a/spec/controllers/company_people_controller_spec.rb
+++ b/spec/controllers/company_people_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
     context 'company admin' do
       before(:each) do
         @company_admin = FactoryBot.create(:company_admin)
-        sign_in @company_admin
+        warden.set_user @company_admin
         get :show, id: @company_admin
       end
       it 'renders show template' do
@@ -42,7 +42,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
     context 'company contact' do
       before(:each) do
         @company_contact = FactoryBot.create(:company_contact)
-        sign_in @company_contact
+        warden.set_user @company_contact
         get :show, id: @company_contact
       end
       it 'renders show template' do
@@ -59,7 +59,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
       context 'company admin' do
         before(:each) do
           @company_admin = FactoryBot.create(:company_admin)
-          sign_in @company_admin
+          warden.set_user @company_admin
           get :edit_profile, id: @company_admin
         end
         it 'renders edit_profile template' do
@@ -73,7 +73,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
       context 'company contact' do
         before(:each) do
           @company_contact = FactoryBot.create(:company_contact)
-          sign_in @company_contact
+          warden.set_user @company_contact
           get :edit_profile, id: @company_contact
         end
 
@@ -140,7 +140,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
   describe 'GET #home' do
     describe 'authorized access' do
       before(:each) do
-        sign_in company_person
+        warden.set_user company_person
         get :home, id: company_person
       end
 
@@ -163,7 +163,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
 
     describe 'xhr response - skills' do
       before(:each) do
-        sign_in company_person
+        warden.set_user company_person
         xhr :get, :home, id: company_person, data_type: 'skills'
       end
 
@@ -174,7 +174,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
 
     describe 'xhr response - licenses' do
       before(:each) do
-        sign_in company_person
+        warden.set_user company_person
         xhr :get, :home, id: company_person, data_type: 'licenses'
       end
 
@@ -224,7 +224,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
     describe 'authorized access' do
       context 'valid attributes' do
         before(:each) do
-          sign_in company_person
+          warden.set_user company_person
           company_person.company_roles <<
             FactoryBot.create(:company_role, role: CompanyRole::ROLE[:CA])
           company_person.save
@@ -251,7 +251,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
                               password: 'testing.....',
                               password_confirmation: 'testing.....')
           @password = @company_person.encrypted_password
-          sign_in @company_person
+          warden.set_user @company_person
           patch :update_profile,
                 company_person:
                   FactoryBot.attributes_for(:company_person,
@@ -365,7 +365,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
   describe 'GET #show' do
     describe 'authorized access' do
       before(:each) do
-        sign_in company_admin
+        warden.set_user company_admin
         get :show, id: company_admin
       end
 
@@ -381,7 +381,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
   describe 'GET #edit' do
     describe 'authorized access' do
       before(:each) do
-        sign_in company_admin
+        warden.set_user company_admin
         get :edit, id: company_admin
       end
 
@@ -397,7 +397,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
   describe 'PATCH #destroy' do
     describe 'authorized access' do
       before(:each) do
-        sign_in company_admin
+        warden.set_user company_admin
         patch :destroy, id: company_person
       end
 
@@ -421,7 +421,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
       before(:each) do
         updated_fields = company_admin.attributes
                                       .merge(company_admin.user.attributes)
-        sign_in company_admin
+        warden.set_user company_admin
         patch :update, id: company_admin, company_person: updated_fields
       end
 
@@ -443,7 +443,7 @@ RSpec.describe CompanyPeopleController, type: :controller do
         updated_fields = company_admin.attributes
                                       .merge(company_admin.user.attributes)
         updated_fields[:company_role_ids] = []
-        sign_in company_admin
+        warden.set_user company_admin
         patch :update, id: company_admin, company_person: updated_fields
       end
 

--- a/spec/controllers/company_registrations_controller_spec.rb
+++ b/spec/controllers/company_registrations_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.shared_examples 'authorized show request' do
   before do
-    # Use `warden.set_user user` instead of `sign_in user` cause the latter
+    # Use `warden.set_user user` instead of `warden.set_user user` cause the latter
     # doesn't set pets_user for some weird reason
     warden.set_user user
     request
@@ -180,7 +180,7 @@ RSpec.describe CompanyRegistrationsController, type: :controller do
     let(:request) { delete :destroy, id: company }
     context 'authorized access' do
       before do
-        sign_in agency_admin
+        warden.set_user agency_admin
         request
       end
       it 'sets flash message' do
@@ -211,7 +211,7 @@ RSpec.describe CompanyRegistrationsController, type: :controller do
 
     context 'authorized access' do
       before(:each) do
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
 
       it 'delete company person(s)' do
@@ -355,7 +355,7 @@ RSpec.describe CompanyRegistrationsController, type: :controller do
         3.times do
           FactoryBot.create(:agency_person, agency: agency)
         end
-        sign_in agency_admin
+        warden.set_user agency_admin
         allow(Companies::ApproveCompanyRegistration)
           .to receive(:new).and_return(use_case_mock)
         allow(use_case_mock)
@@ -420,7 +420,7 @@ RSpec.describe CompanyRegistrationsController, type: :controller do
         allow(use_case_mock)
           .to receive(:call)
         post :create, company: registration_params
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
 
       context 'after denial' do
@@ -494,7 +494,7 @@ RSpec.describe CompanyRegistrationsController, type: :controller do
           FactoryBot.create(:agency_person, agency: agency)
         end
         post :create, company: registration_params
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
 
       it 'updates person and address but does not add person or address' do

--- a/spec/controllers/job_applications_controller_spec.rb
+++ b/spec/controllers/job_applications_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe JobApplicationsController, type: :controller do
     context 'authenticated' do
       describe 'authorized access' do
         before do
-          sign_in company_admin
+          warden.set_user company_admin
           request
         end
 
@@ -107,7 +107,7 @@ RSpec.describe JobApplicationsController, type: :controller do
       describe 'authorized access' do
         let(:hire_mock) { double(JobApplications::Hire) }
         before(:each) do
-          sign_in company_admin
+          warden.set_user company_admin
           allow(JobApplications::Hire).to receive(:new)
             .and_return(hire_mock)
         end
@@ -173,7 +173,7 @@ RSpec.describe JobApplicationsController, type: :controller do
         let(:reject_mock) { double(JobApplications::Reject) }
 
         before(:each) do
-          sign_in company_admin
+          warden.set_user company_admin
           allow(JobApplications::Reject).to receive(:new)
             .and_return(reject_mock)
         end
@@ -236,7 +236,7 @@ RSpec.describe JobApplicationsController, type: :controller do
       describe 'authorized access' do
         let(:application_process_mock) { double(JobApplications::Processing) }
         before(:each) do
-          sign_in company_admin
+          warden.set_user company_admin
           allow(JobApplications::Processing).to receive(:new)
             .and_return(application_process_mock)
         end

--- a/spec/controllers/job_categories_controller_spec.rb
+++ b/spec/controllers/job_categories_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe JobCategoriesController, type: :controller do
     context 'authorized access' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
       it 'creates new job category for valid parameters' do
         expect { xhr :post, :create, job_category: jobcat_params }
@@ -71,7 +71,7 @@ RSpec.describe JobCategoriesController, type: :controller do
     context 'authorized access' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
       context 'job category found' do
         before(:each) do
@@ -110,7 +110,7 @@ RSpec.describe JobCategoriesController, type: :controller do
     context 'authorized access' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
 
       it 'returns success for valid parameters' do
@@ -141,7 +141,7 @@ RSpec.describe JobCategoriesController, type: :controller do
     context 'authorized access' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
       context 'job category found' do
         it 'deletes job category' do

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe JobSeekersController, type: :controller do
       before(:each) do
         stub_cruncher_authenticate
         stub_cruncher_file_upload
-        sign_in owner
+        warden.set_user owner
       end
       it 'updates email address' do
         patch :update, id: owner, job_seeker: FactoryBot
@@ -397,7 +397,7 @@ RSpec.describe JobSeekersController, type: :controller do
     context ' related case manager ' do
       let(:password) { owner.encrypted_password }
       before(:each) do
-        sign_in owner_case_manager
+        warden.set_user owner_case_manager
       end
       context 'valid attributes' do
         it 'locates the requested @jobseeker' do
@@ -456,7 +456,7 @@ RSpec.describe JobSeekersController, type: :controller do
     context ' related job_developer ' do
       let(:password) { owner.encrypted_password }
       before(:each) do
-        sign_in owner_job_developer
+        warden.set_user owner_job_developer
       end
       context 'valid attributes' do
         it 'locates the requested @jobseeker' do
@@ -555,7 +555,7 @@ RSpec.describe JobSeekersController, type: :controller do
         stub_cruncher_authenticate
         stub_cruncher_file_upload
 
-        sign_in owner
+        warden.set_user owner
         request
       end
       it 'assigns jobseeker and current_resume for view' do
@@ -590,7 +590,7 @@ RSpec.describe JobSeekersController, type: :controller do
     end
     context 'owner' do
       before :each do
-        sign_in owner
+        warden.set_user owner
         request
       end
       it 'renders homepage template' do
@@ -610,9 +610,9 @@ RSpec.describe JobSeekersController, type: :controller do
         @newjob.assign_attributes(created_at: Time.now)
         @oldjob = FactoryBot.create(:job)
         @oldjob.update_attributes(created_at: Time.now - 2.weeks)
-        owner.assign_attributes(last_sign_in_at: (Time.now - 1.week))
-        expect(Job.new_jobs(owner.last_sign_in_at)).to include(@newjob)
-        expect(Job.new_jobs(owner.last_sign_in_at)).not_to include(@oldjob)
+        owner.assign_attributes(last_warden.set_user_at: (Time.now - 1.week))
+        expect(Job.new_jobs(owner.last_warden.set_user_at)).to include(@newjob)
+        expect(Job.new_jobs(owner.last_warden.set_user_at)).not_to include(@oldjob)
       end
     end
   end
@@ -635,7 +635,7 @@ RSpec.describe JobSeekersController, type: :controller do
       it_behaves_like 'unauthorized to js controller', 'job_seeker'
     end
     it 'renders the index template' do
-      sign_in FactoryBot.create(:agency_admin)
+      warden.set_user FactoryBot.create(:agency_admin)
       request
       expect(response.body).to render_template 'index'
     end
@@ -661,7 +661,7 @@ RSpec.describe JobSeekersController, type: :controller do
     end
     context 'owner' do
       before(:each) do
-        sign_in owner
+        warden.set_user owner
         request
       end
       # the job seeker should not be able to see their show page
@@ -703,7 +703,7 @@ RSpec.describe JobSeekersController, type: :controller do
     end
     context 'related job_developer' do
       it "it renders job seeker's info partial" do
-        sign_in owner_job_developer
+        warden.set_user owner_job_developer
         request
         expect(response).to render_template(partial: '_info')
       end
@@ -739,7 +739,7 @@ RSpec.describe JobSeekersController, type: :controller do
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create
-      sign_in jobseeker
+      warden.set_user jobseeker
     end
     context 'User without a resume' do
       before(:each) do
@@ -815,7 +815,7 @@ RSpec.describe JobSeekersController, type: :controller do
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create
-      sign_in company_admin
+      warden.set_user company_admin
     end
 
     let(:company)       { FactoryBot.create(:company) }

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -610,9 +610,9 @@ RSpec.describe JobSeekersController, type: :controller do
         @newjob.assign_attributes(created_at: Time.now)
         @oldjob = FactoryBot.create(:job)
         @oldjob.update_attributes(created_at: Time.now - 2.weeks)
-        owner.assign_attributes(last_warden.set_user_at: (Time.now - 1.week))
-        expect(Job.new_jobs(owner.last_warden.set_user_at)).to include(@newjob)
-        expect(Job.new_jobs(owner.last_warden.set_user_at)).not_to include(@oldjob)
+        last_login_time = Time.now - 1.week
+        expect(Job.new_jobs(last_login_time)).to include(@newjob)
+        expect(Job.new_jobs(last_login_time)).not_to include(@oldjob)
       end
     end
   end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -584,7 +584,7 @@ RSpec.describe JobsController, type: :controller do
         # Next line added to ensure the query is done and that the
         # paginate is also called
         request_first_page
-        assigns(:jobs).each {}
+        assigns(:jobs).each{}
         expect(assigns(:jobs).all.size).to be 10
         expect(assigns(:jobs).first.title).to eq 'Awesome job 00'
         expect(assigns(:jobs).last.title).to eq 'Awesome job 09'
@@ -605,7 +605,7 @@ RSpec.describe JobsController, type: :controller do
         # Next line added to ensure the query is done and that the
         # paginate is also called
         request_last_page
-        assigns(:jobs).each {}
+        assigns(:jobs).each{}
         expect(assigns(:jobs).first.title).to eq 'Awesome job 30'
         expect(assigns(:jobs).size).to eq 1
       end
@@ -626,7 +626,7 @@ RSpec.describe JobsController, type: :controller do
       it 'check jobs' do
         # Next line added to ensure the query is done and that the
         # paginate is also called
-        assigns(:jobs).each {}
+        assigns(:jobs).each{}
         expect(assigns(:jobs).all.size).to be 4
         expect(assigns(:jobs).first.title).to eq 'Awesome new job 0'
         expect(assigns(:jobs).last.title).to eq 'Awesome new job 3'

--- a/spec/controllers/licenses_controller_spec.rb
+++ b/spec/controllers/licenses_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe LicensesController, type: :controller do
   describe 'POST #create' do
     context 'authorized access - agency admin' do
       before :each do
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
       it 'creates new license for valid parameters' do
         expect { xhr :post, :create, license: license_params }
@@ -62,7 +62,7 @@ RSpec.describe LicensesController, type: :controller do
   describe 'GET #show' do
     context 'authorized access - agency admin' do
       before :each do
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
 
       context 'license found' do
@@ -98,7 +98,7 @@ RSpec.describe LicensesController, type: :controller do
   describe 'PATCH #update' do
     context 'authorized access - agency admin' do
       before :each do
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
       it 'returns success for valid parameters' do
         xhr :patch, :update, id: license, license: license_params
@@ -125,7 +125,7 @@ RSpec.describe LicensesController, type: :controller do
 
     context 'authorized access - agency admin' do
       before :each do
-        sign_in agency_admin
+        warden.set_user agency_admin
       end
 
       let!(:job_license) { FactoryBot.create(:job_license, license: license) }

--- a/spec/controllers/people_invitations_controller_spec.rb
+++ b/spec/controllers/people_invitations_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in agency_admin
+        warden.set_user agency_admin
         get :new, person_type: 'AgencyPerson', org_id: agency.id
       end
       it 'sets session key for person_type' do
@@ -32,7 +32,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
     it 'sends invitation email' do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      sign_in agency_admin
+      warden.set_user agency_admin
       expect { post :create, user: FactoryBot.attributes_for(:user) }
         .to change(all_emails, :count).by(+1)
     end
@@ -44,7 +44,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in agency_admin
+        warden.set_user agency_admin
         post :create, { user: user_hash },
              # following arg is session variables
              person_type: 'AgencyPerson', org_id: agency.id
@@ -72,14 +72,14 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       it 'creates user once upon initial invite' do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in agency_admin
+        warden.set_user agency_admin
         expect { 4.times { post :create, user: user_hash } }
           .to change(User, :count).by(+1)
       end
 
       it 'resends invitation to same user' do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in agency_admin
+        warden.set_user agency_admin
         expect { 4.times { post :create, user: user_hash } }
           .to change(all_emails, :count).by(+4)
       end
@@ -96,7 +96,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in agency_admin
+        warden.set_user agency_admin
         post :create, { user: user_hash },
              # following arg is session variables
              person_type: 'AgencyPerson', org_id: agency.id
@@ -128,7 +128,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in company_admin
+        warden.set_user company_admin
         get :new, person_type: 'CompanyPerson', org_id: company.id
       end
       it 'sets session key for person_type' do
@@ -162,7 +162,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
     it 'sends invitation email' do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      sign_in company_admin
+      warden.set_user company_admin
       expect { post :create, user: FactoryBot.attributes_for(:user) }
         .to change(all_emails, :count).by(+1)
     end
@@ -184,7 +184,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in company_admin
+        warden.set_user company_admin
         post :create, { user: user_hash },
              # following arg is session variables
              person_type: 'CompanyPerson', org_id: company.id
@@ -222,14 +222,14 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       it 'creates user once upon initial invite' do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in company_admin
+        warden.set_user company_admin
         expect { 4.times { post :create, user: user_hash } }
           .to change(User, :count).by(+1)
       end
 
       it 'resends invitation to same user' do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in company_admin
+        warden.set_user company_admin
         expect { 4.times { post :create, user: user_hash } }
           .to change(all_emails, :count).by(+4)
       end
@@ -256,7 +256,7 @@ RSpec.describe PeopleInvitationsController, type: :controller do
 
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        sign_in company_admin
+        warden.set_user company_admin
         post :create, { user: user_hash },
              # following arg is session variables
              person_type: 'CompanyPerson', org_id: company.id

--- a/spec/controllers/skills_controller_spec.rb
+++ b/spec/controllers/skills_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - agency admin' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
       it 'creates new skill for valid parameters' do
         expect { xhr :post, :create, skill: skill_params }
@@ -66,7 +66,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company admin' do
       before :each do
         ca = FactoryBot.create(:company_admin, company: company)
-        sign_in ca
+        warden.set_user ca
       end
 
       it 'creates new skill for valid parameters' do
@@ -89,7 +89,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company contact' do
       before :each do
         cc = FactoryBot.create(:company_contact, company: company)
-        sign_in cc
+        warden.set_user cc
       end
       it 'creates new skill for valid parameters' do
         expect { xhr :post, :create, skill: skill_params_company }
@@ -117,7 +117,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - agency admin' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
       context 'skill found' do
         before(:each) do
@@ -147,7 +147,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company admin' do
       before :each do
         ca = FactoryBot.create(:company_admin, company: company)
-        sign_in ca
+        warden.set_user ca
       end
       context 'skill found' do
         before(:each) do
@@ -177,7 +177,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company contact' do
       before :each do
         cc = FactoryBot.create(:company_contact, company: company)
-        sign_in cc
+        warden.set_user cc
       end
       context 'skill found' do
         before(:each) do
@@ -213,7 +213,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - agency admin' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
       it 'returns success for valid parameters' do
         xhr :patch, :update, id: skill, skill: skill_params
@@ -230,7 +230,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company admin' do
       before :each do
         ca = FactoryBot.create(:company_admin, company: company)
-        sign_in ca
+        warden.set_user ca
       end
       it 'returns success for valid parameters' do
         xhr :patch, :update, id: company_skill, skill: skill_params
@@ -247,7 +247,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company contact' do
       before :each do
         cc = FactoryBot.create(:company_contact, company: company)
-        sign_in cc
+        warden.set_user cc
       end
       it 'returns success for valid parameters' do
         xhr :patch, :update, id: company_skill, skill: skill_params
@@ -275,7 +275,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - agency admin' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
 
       let!(:job_skill) { FactoryBot.create(:job_skill, skill: skill) }
@@ -307,7 +307,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company admin' do
       before :each do
         ca = FactoryBot.create(:company_admin, company: company)
-        sign_in ca
+        warden.set_user ca
       end
 
       let!(:job_skill) { FactoryBot.create(:job_skill, skill: company_skill) }
@@ -340,7 +340,7 @@ RSpec.describe SkillsController, type: :controller do
     context 'authorized access - company contact' do
       before :each do
         cc = FactoryBot.create(:company_contact, company: company)
-        sign_in cc
+        warden.set_user cc
       end
 
       let!(:job_skill) { FactoryBot.create(:job_skill, skill: company_skill) }

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TasksController, type: :controller do
         @jd4 = FactoryBot.create(:job_developer, agency: agency)
         js = FactoryBot.create(:job_seeker)
         @task = Task.new_js_unassigned_jd_task js, agency
-        sign_in @jd1
+        warden.set_user @jd1
       end
 
       subject { xhr :patch, :assign, { id: @task.id }, format: :json }
@@ -25,7 +25,7 @@ RSpec.describe TasksController, type: :controller do
       before :each do
         agency = FactoryBot.create(:agency)
         @jd1 = FactoryBot.create(:job_developer, agency: agency)
-        sign_in @jd1
+        warden.set_user @jd1
       end
 
       describe 'missing parameters' do
@@ -61,7 +61,7 @@ RSpec.describe TasksController, type: :controller do
           aa = FactoryBot.create(:agency_admin, agency: agency)
           js = FactoryBot.create(:job_seeker)
           @task = Task.new_js_unassigned_jd_task js, agency
-          sign_in aa
+          warden.set_user aa
         end
 
         subject do
@@ -83,7 +83,7 @@ RSpec.describe TasksController, type: :controller do
           aa = FactoryBot.create(:agency_admin, agency: agency)
           @js = FactoryBot.create(:job_seeker)
           @task = Task.new_js_unassigned_jd_task @js, agency
-          sign_in aa
+          warden.set_user aa
         end
 
         subject do
@@ -125,7 +125,7 @@ RSpec.describe TasksController, type: :controller do
         js = FactoryBot.create(:job_seeker)
         @task = Task.new_js_unassigned_jd_task js, agency
         @task.assign @jd1
-        sign_in @jd1
+        warden.set_user @jd1
       end
 
       subject { xhr :patch, :in_progress, { id: @task.id }, format: :json }
@@ -143,7 +143,7 @@ RSpec.describe TasksController, type: :controller do
       before :each do
         agency = FactoryBot.create(:agency)
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
 
       describe 'Cannot find task' do
@@ -210,7 +210,7 @@ RSpec.describe TasksController, type: :controller do
         @task = Task.new_js_unassigned_jd_task js, agency
         @task.assign @jd1
         @task.work_in_progress
-        sign_in @jd1
+        warden.set_user @jd1
       end
 
       subject { xhr :patch, :done, { id: @task.id }, format: :json }
@@ -228,7 +228,7 @@ RSpec.describe TasksController, type: :controller do
       before :each do
         agency = FactoryBot.create(:agency)
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
 
       describe 'Cannot find task' do
@@ -302,7 +302,7 @@ RSpec.describe TasksController, type: :controller do
     describe 'authorized access' do
       before :each do
         aa = FactoryBot.create(:agency_admin, agency: agency)
-        sign_in aa
+        warden.set_user aa
       end
 
       describe 'retrieve information' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Users::SessionsController, type: :controller do
     it 'logs in without remember me' do
       post :create,
            user: { email: user.email, password: user.password,
-                   person_type: user.actable_type }
+                   person_type: user.user_type }
       expect(cookies[:user_id]).to eq user.id
-      expect(cookies[:person_type]).to eq user.actable_type
+      expect(cookies[:person_type]).to eq user.user_type
     end
   end
   describe 'POST #create /users/sessions with remember me' do
@@ -22,13 +22,13 @@ RSpec.describe Users::SessionsController, type: :controller do
       post :create,
            user: { email: user.email, password: user.password,
                    remember_me: '1',
-                   person_type: user.actable_type }
+                   person_type: user.user_type }
       user_id_cookie = stub_cookie_jar[:user_id]
       expect(user_id_cookie[:value]).to eq user.id
       expect(user_id_cookie[:expires])
         .to be_within(5.seconds).of 1.year.from_now
       person_type_cookie = stub_cookie_jar[:person_type]
-      expect(person_type_cookie[:value]).to eq user.actable_type
+      expect(person_type_cookie[:value]).to eq user.user_type
       expect(person_type_cookie[:expires])
         .to be_within(5.seconds).of 1.year.from_now
     end

--- a/spec/factories/job_seekers.rb
+++ b/spec/factories/job_seekers.rb
@@ -3,8 +3,9 @@ FactoryBot.define do
     year_of_birth '1998'
     job_seeker_status
     association :address, factory: :address
-    user
+    association :user, factory: :user
   end
+
   factory :job_seeker_applicant, class: JobSeeker do
     year_of_birth '1998'
     job_seeker_status

--- a/spec/interactors/agency_people/assign_new_job_seekers_spec.rb
+++ b/spec/interactors/agency_people/assign_new_job_seekers_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
-RSpec.describe AgencyPeople::AssignNewJobSeekers do
+
+RSpec.describe AgencyPeople::AssignNewJobSeekers, type: :interactor do
   describe '#call' do
     let!(:agency)       { FactoryBot.create(:agency) }
     let(:job_developer) { FactoryBot.create(:job_developer, agency: agency) }

--- a/spec/mailers/previews/agency_mailer_preview.rb
+++ b/spec/mailers/previews/agency_mailer_preview.rb
@@ -54,7 +54,7 @@ class AgencyMailerPreview < ActionMailer::Preview
                      company: Company.first,
                      company_job_id: 'XYZ',
                      description: 'description of test job')
-    job_developer = User.find_by_email('chet@metplus.org').actable
+    job_developer = User.find_by_email('chet@metplus.org').pets_user
 
     AgencyMailer.job_posted(job_developer.email, job)
   end
@@ -65,7 +65,7 @@ class AgencyMailerPreview < ActionMailer::Preview
                      company: Company.first,
                      company_job_id: 'XYZ',
                      description: 'description of test job')
-    job_developer = User.find_by_email('chet@metplus.org').actable
+    job_developer = User.find_by_email('chet@metplus.org').pets_user
 
     AgencyMailer.job_revoked(job_developer.email, job)
   end

--- a/spec/mailers/previews/job_seeker_mailer_preview.rb
+++ b/spec/mailers/previews/job_seeker_mailer_preview.rb
@@ -22,7 +22,7 @@ class JobSeekerMailerPreview < ActionMailer::Preview
   end
 
   def job_revoked
-    job_seeker = User.find_by_email('tomseekerpets@gmail.com').actable
+    job_seeker = User.find_by_email('tomseekerpets@gmail.com').pets_user
 
     stub_cruncher_authenticate
     stub_cruncher_job_create

--- a/spec/models/agency_person_spec.rb
+++ b/spec/models/agency_person_spec.rb
@@ -125,16 +125,6 @@ RSpec.describe AgencyPerson, type: :model do
       agency.valid?
       expect(agency.errors[:agency_id]).to include("can't be blank")
     end
-    context '#acting_as?' do
-      it 'returns true for supermodel class and name' do
-        expect(AgencyPerson.acting_as?(:user)).to be true
-        expect(AgencyPerson.acting_as?(User)).to  be true
-      end
-      it 'returns false for anything other than supermodel' do
-        expect(AgencyPerson.acting_as?(:model)).to be false
-        expect(AgencyPerson.acting_as?(String)).to be false
-      end
-    end
   end
 
   describe 'Agency Admin checks' do

--- a/spec/models/company_person_spec.rb
+++ b/spec/models/company_person_spec.rb
@@ -90,36 +90,6 @@ describe CompanyPerson, type: :model do
     end
   end
 
-  describe 'check model restrictions' do
-    it { should validate_presence_of(:email) }
-    it { should_not allow_value('abc', 'abc@abc', 'abcdefghjjkll').for(:email) }
-    it { is_expected.to validate_presence_of :first_name }
-    it { is_expected.to validate_presence_of :last_name }
-    it {
-      should_not allow_value('asd', '123456', '123 1231  1234', '1    123 123 1234',
-                             ' 123 123 1234', '(234 1234 1234',
-                             '786) 1243 3578').for(:phone)
-    }
-    it {
-      should allow_value('+1 123 123 1234', '123 123 1234', '(123) 123 1234',
-                         '1 231 231 2345', '12312312345', '1231231234',
-                         '1-910-123-9158 x2851', '1-872-928-5886',
-                         '833-638-6551 x16825').for(:phone)
-    }
-  end
-
-  context '#acting_as?' do
-    it 'returns true for supermodel class and name' do
-      expect(CompanyPerson.acting_as?(:user)).to be true
-      expect(CompanyPerson.acting_as?(User)).to  be true
-    end
-
-    it 'returns false for anything other than supermodel' do
-      expect(CompanyPerson.acting_as?(:model)).to be false
-      expect(CompanyPerson.acting_as?(String)).to be false
-    end
-  end
-
   describe '#is_company_contact?' do
     let(:company) { FactoryBot.create(:company) }
     let(:company1) { FactoryBot.create(:company) }

--- a/spec/models/job_seeker_spec.rb
+++ b/spec/models/job_seeker_spec.rb
@@ -78,6 +78,7 @@ describe JobSeeker, type: :model do
       stub_cruncher_authenticate
       stub_cruncher_job_create
       stub_cruncher_file_download test_file
+      stub_cruncher_file_upload
     end
 
     it '#latest_application' do
@@ -138,17 +139,6 @@ describe JobSeeker, type: :model do
     end
   end
 
-  context '#acting_as?' do
-    it 'returns true for supermodel class and name' do
-      expect(JobSeeker.acting_as?(:user)).to be true
-      expect(JobSeeker.acting_as?(User)).to  be true
-    end
-
-    it 'returns false for anything other than supermodel' do
-      expect(JobSeeker.acting_as?(:model)).to be false
-      expect(JobSeeker.acting_as?(String)).to be false
-    end
-  end
   describe '#is_job_seeker?' do
     let(:person) { FactoryBot.create(:job_seeker) }
     it 'true' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of :last_name }
     it {
       should_not allow_value('asd', '123456', '123 1231  1234', '1    123 123 1234',
-                              ' 123 123 1234', '(234 1234 1234',
-                              '786) 1243 3578').for(:phone)
+                             ' 123 123 1234', '(234 1234 1234',
+                             '786) 1243 3578').for(:phone)
     }
 
     describe 'Phone number format check' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :last_name }
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :phone }
-    it { is_expected.to have_db_column :actable_id }
-    it { is_expected.to have_db_column :actable_type }
 
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :reset_password_token }
@@ -36,15 +34,15 @@ RSpec.describe User, type: :model do
   end
 
   describe 'check model restrictions' do
-    describe 'FirstName check' do
-      subject { FactoryBot.build(:user) }
-      it { is_expected.to validate_presence_of :first_name }
-    end
-
-    describe 'LastName check' do
-      subject { FactoryBot.build(:user) }
-      it { is_expected.to validate_presence_of :last_name }
-    end
+    it { should validate_presence_of(:email) }
+    it { should_not allow_value('abc', 'abc@abc', 'abcdefghjjkll').for(:email) }
+    it { is_expected.to validate_presence_of :first_name }
+    it { is_expected.to validate_presence_of :last_name }
+    it {
+      should_not allow_value('asd', '123456', '123 1231  1234', '1    123 123 1234',
+                              ' 123 123 1234', '(234 1234 1234',
+                              '786) 1243 3578').for(:phone)
+    }
 
     describe 'Phone number format check' do
       subject { FactoryBot.build(:user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :reset_password_token }
     it { is_expected.to have_db_column :reset_password_sent_at }
     it { is_expected.to have_db_column :remember_created_at }
-    it { is_expected.to have_db_column :sign_in_count }
+    it { is_expected.to have_db_column :warden.set_user_count }
 
-    it { is_expected.to have_db_column :current_sign_in_at }
-    it { is_expected.to have_db_column :last_sign_in_at }
+    it { is_expected.to have_db_column :current_warden.set_user_at }
+    it { is_expected.to have_db_column :last_warden.set_user_at }
     it { is_expected.to have_db_column :confirmation_token }
-    it { is_expected.to have_db_column :current_sign_in_ip }
-    it { is_expected.to have_db_column :last_sign_in_ip }
+    it { is_expected.to have_db_column :current_warden.set_user_ip }
+    it { is_expected.to have_db_column :last_warden.set_user_ip }
     it { is_expected.to have_db_column :confirmation_token }
 
     it { is_expected.to have_db_column :confirmed_at }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,5 +71,5 @@ Shoulda::Matchers.configure do |config|
 end
 # Make the devise controllers and views available to spec
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -135,13 +135,13 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
+  # config.before(:each) do
+  #   DatabaseCleaner.start
+  # end
 
-  config.append_after(:each) do
-    DatabaseCleaner.clean
-  end
+  # config.append_after(:each) do
+  #   DatabaseCleaner.clean
+  # end
 
   config.include(EmailSpec::Helpers)
   config.include(EmailSpec::Matchers)


### PR DESCRIPTION
This will be the first step to update rails to 5.1 since act_as gem is not supported in that version.
Removing act_as also allow us to think about the possibility of having tests that do not depend on the database, making them much faster then they currently are

related to AgileVentures/MetPlus_tracker/issues/724