### PR TITLE
When the Job Seeker as no resume the application does not raise exception

### DIFF
--- a/app/mailers/company_mailer.rb
+++ b/app/mailers/company_mailer.rb
@@ -21,18 +21,23 @@ class CompanyMailer < ApplicationMailer
     @job_application = job_application
     @job = @job_application.job
     @job_seeker = @job_application.job_seeker
+    @has_resume = !resume_id.nil?
 
-    # Download the resume from Cruncher
-    resume_temp_file = ResumeCruncher.download_resume(resume_id)
-    file_name = @job_seeker.resumes.first.file_name
-    attachments[file_name] = File.read(resume_temp_file.path)
+    if @has_resume
+      # Download the resume from Cruncher
+      resume_temp_file = ResumeCruncher.download_resume(resume_id)
+      file_name = @job_seeker.resumes.first.file_name
+      attachments[file_name] = File.read(resume_temp_file.path)
+    end
 
     mail(to: company.job_email, from: ENV['NOTIFICATION_EMAIL'],
          subject: 'Job Application received')
 
-    # On windows, unlinking a file before closing fails
-    # For more, see http://docs.cs.up.ac.za/programming/ruby/ruby_2_2_0_stdlib/libdoc/tempfile/rdoc/Tempfile.html#method-i-unlink-label-Unlink-before-close
-    resume_temp_file.close(unlink_now=true)
+    if @has_resume
+      # On windows, unlinking a file before closing fails
+      # For more, see http://docs.cs.up.ac.za/programming/ruby/ruby_2_2_0_stdlib/libdoc/tempfile/rdoc/Tempfile.html#method-i-unlink-label-Unlink-before-close
+      resume_temp_file.close(unlink_now=true)
+    end
   end
 
   private

--- a/app/mailers/company_mailer.rb
+++ b/app/mailers/company_mailer.rb
@@ -36,7 +36,7 @@ class CompanyMailer < ApplicationMailer
     if @has_resume
       # On windows, unlinking a file before closing fails
       # For more, see http://docs.cs.up.ac.za/programming/ruby/ruby_2_2_0_stdlib/libdoc/tempfile/rdoc/Tempfile.html#method-i-unlink-label-Unlink-before-close
-      resume_temp_file.close(unlink_now=true)
+      resume_temp_file.close(true)
     end
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -108,14 +108,15 @@ class Job < ActiveRecord::Base
     end
 
     if job_application.save!
-
+      resume = nil
+      resume = job_seeker.resumes[0].id if job_seeker.resumes.length > 0
       # Send mail to the company with the attached resume
       CompanyMailerJob.set(wait: Event.delay_seconds.seconds)
                       .perform_later(Event::EVT_TYPE[:JS_APPLY],
                                      company,
                                      nil,
                                      application: job_application,
-                                     resume_id: job_seeker.resumes[0].id)
+                                     resume_id: resume)
       yield(job_application, self, job_seeker) if block_given?
       job_application
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -108,15 +108,7 @@ class Job < ActiveRecord::Base
     end
 
     if job_application.save!
-      resume = nil
-      resume = job_seeker.resumes[0].id unless job_seeker.resumes.empty?
-      # Send mail to the company with the attached resume
-      CompanyMailerJob.set(wait: Event.delay_seconds.seconds)
-                      .perform_later(Event::EVT_TYPE[:JS_APPLY],
-                                     company,
-                                     nil,
-                                     application: job_application,
-                                     resume_id: resume)
+      send_application_email_to_company job_seeker, job_application
       yield(job_application, self, job_seeker) if block_given?
       job_application
     end
@@ -184,4 +176,15 @@ class Job < ActiveRecord::Base
     true
   end
 
+  def send_application_email_to_company(job_seeker, job_application)
+    resume = nil
+    resume = job_seeker.resumes[0].id unless job_seeker.resumes.empty?
+    # Send mail to the company with the attached resume
+    CompanyMailerJob.set(wait: Event.delay_seconds.seconds)
+                    .perform_later(Event::EVT_TYPE[:JS_APPLY],
+                                   company,
+                                   nil,
+                                   application: job_application,
+                                   resume_id: resume)
+  end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -109,7 +109,7 @@ class Job < ActiveRecord::Base
 
     if job_application.save!
       resume = nil
-      resume = job_seeker.resumes[0].id if !job_seeker.resumes.empty?
+      resume = job_seeker.resumes[0].id unless job_seeker.resumes.empty?
       # Send mail to the company with the attached resume
       CompanyMailerJob.set(wait: Event.delay_seconds.seconds)
                       .perform_later(Event::EVT_TYPE[:JS_APPLY],

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -109,7 +109,7 @@ class Job < ActiveRecord::Base
 
     if job_application.save!
       resume = nil
-      resume = job_seeker.resumes[0].id if job_seeker.resumes.length > 0
+      resume = job_seeker.resumes[0].id if !job_seeker.resumes.empty?
       # Send mail to the company with the attached resume
       CompanyMailerJob.set(wait: Event.delay_seconds.seconds)
                       .perform_later(Event::EVT_TYPE[:JS_APPLY],

--- a/app/views/company_mailer/application_received.html.haml
+++ b/app/views/company_mailer/application_received.html.haml
@@ -7,7 +7,10 @@
   = link_to @job_seeker.full_name(last_name_first: false), job_seeker_url(@job_seeker)
 
 %p
+- if @has_resume
   Please find the resume of the applicant attached with this email.
+- else
+  No resume was provided
 
 - questions = @job_application.application_questions
 

--- a/spec/mailers/company_mailer_spec.rb
+++ b/spec/mailers/company_mailer_spec.rb
@@ -66,8 +66,7 @@ RSpec.describe CompanyMailer, type: :mailer do
 
     describe 'when the Job Seeker as a resume' do
       let(:mail) do
-        CompanyMailer.application_received(company,
-                                          job_application, resume.id)
+        CompanyMailer.application_received(company, job_application, resume.id)
       end
 
       it 'renders the headers' do
@@ -83,7 +82,8 @@ RSpec.describe CompanyMailer, type: :mailer do
 
       it 'renders information the Job Seeker did send resume' do
         expect(mail)
-          .to have_body_text('Please find the resume of the applicant attached with this email')
+          .to have_body_text('Please find the resume of the applicant attached '\
+                             'with this email')
       end
 
       it 'renders links for job title and job seeker' do
@@ -99,8 +99,7 @@ RSpec.describe CompanyMailer, type: :mailer do
 
     describe 'when the Job Seeker as no resume' do
       let(:mail) do
-        CompanyMailer.application_received(company,
-                                          job_application, nil)
+        CompanyMailer.application_received(company, job_application, nil)
       end
 
       it 'renders the headers' do

--- a/spec/mailers/company_mailer_spec.rb
+++ b/spec/mailers/company_mailer_spec.rb
@@ -57,36 +57,76 @@ RSpec.describe CompanyMailer, type: :mailer do
     end
     let!(:test_file) { '../fixtures/files/Admin-Assistant-Resume.pdf' }
 
-    let(:mail) do
-      CompanyMailer.application_received(company,
-                                         job_application, resume.id)
-    end
-
     before do
       stub_cruncher_authenticate
       stub_cruncher_job_create
       stub_cruncher_file_download test_file
+      stub_cruncher_file_upload
     end
 
-    it 'renders the headers' do
-      expect(mail.subject).to eq 'Job Application received'
-      expect(mail.from).to eq [ENV['NOTIFICATION_EMAIL']]
-      expect(mail.to).to eq [company.job_email]
+    describe 'when the Job Seeker as a resume' do
+      let(:mail) do
+        CompanyMailer.application_received(company,
+                                          job_application, resume.id)
+      end
+
+      it 'renders the headers' do
+        expect(mail.subject).to eq 'Job Application received'
+        expect(mail.from).to eq [ENV['NOTIFICATION_EMAIL']]
+        expect(mail.to).to eq [company.job_email]
+      end
+
+      it 'renders the body' do
+        expect(mail)
+          .to have_body_text('you have received an application')
+      end
+
+      it 'renders information the Job Seeker did send resume' do
+        expect(mail)
+          .to have_body_text('Please find the resume of the applicant attached with this email')
+      end
+
+      it 'renders links for job title and job seeker' do
+        expect(mail.body.encoded).to have_link('', href: job_url(job))
+        expect(mail.body.encoded).to have_link('', href: job_seeker_url(job_seeker))
+      end
+
+      it 'renders the attachment' do
+        expect(mail.attachments.length).to eq(1)
+        expect(mail.attachments.last.filename).to eq(resume.file_name)
+      end
     end
 
-    it 'renders the body' do
-      expect(mail)
-        .to have_body_text('you have received an application')
-    end
+    describe 'when the Job Seeker as no resume' do
+      let(:mail) do
+        CompanyMailer.application_received(company,
+                                          job_application, nil)
+      end
 
-    it 'renders links for job title and job seeker' do
-      expect(mail.body.encoded).to have_link('', href: job_url(job))
-      expect(mail.body.encoded).to have_link('', href: job_seeker_url(job_seeker))
-    end
+      it 'renders the headers' do
+        expect(mail.subject).to eq 'Job Application received'
+        expect(mail.from).to eq [ENV['NOTIFICATION_EMAIL']]
+        expect(mail.to).to eq [company.job_email]
+      end
 
-    it 'renders the attachment' do
-      expect(mail.attachments.length).to eq(1)
-      expect(mail.attachments.last.filename).to eq(resume.file_name)
+      it 'renders information the Job Seeker did not send resume' do
+        expect(mail)
+          .to have_body_text('No resume was provided')
+      end
+
+      it 'renders the body' do
+        expect(mail)
+          .to have_body_text('you have received an application')
+      end
+
+      it 'renders links for job title and job seeker' do
+        expect(mail.body.encoded).to have_link('', href: job_url(job))
+        expect(mail.body.encoded).to have_link('', href: job_seeker_url(job_seeker))
+      end
+
+      it 'does not render the attachment' do
+        expect(mail.attachments.length).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -271,11 +271,21 @@ RSpec.describe Job, type: :model do
         expect(job.last_application_by_job_seeker(job_seeker2))
           .to eq second_appl
       end
+
       it 'application with answers to job questions' do
         application = job.apply(job_seeker, question_answers)
         expect(application.application_questions.count).to eq 2
         expect(application.application_questions.first.answer).to be true
         expect(application.application_questions.second.answer).to be false
+      end
+
+      it 'application with job seeker wit no resume' do
+        num_applications = job.number_applicants
+        job_seeker.resumes = []
+        job.apply(job_seeker)
+        job.reload
+        expect(job.job_seekers).to eq [job_seeker]
+        expect(job.number_applicants).to be(num_applications + 1)
       end
     end
   end


### PR DESCRIPTION
Closes AgileVentures/MetPlus_tracker#678

When the Job Seeker as not resume instead of raising an exception it informs the Company Person that no resume was provided.

This might be a temporary fix and we might need to require a Resume for the Job Seeker when applying to a job