### PR TITLE
Closes AgileVentures/MetPlus_tracker#699

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -41,7 +41,7 @@ class TasksController < ApplicationController
     begin
       task.work_in_progress
     rescue Exception => e
-      return render json: {:message => e.message}, status: 500 if user.nil?
+      return render json: {:message => e.message}, status: 500
     end
     render json: {:message => 'Task work in progress'}
   end
@@ -54,7 +54,7 @@ class TasksController < ApplicationController
     begin
       task.complete
     rescue Exception => e
-      return render json: {:message => e.message}, status: 500 if user.nil?
+      return render json: {:message => e.message}, status: 500
     end
     render json: {:message => 'Task finished'}
   end


### PR DESCRIPTION
Flow to trigger the same bug:
1. call `user` variable in the method `TaskController#in_progress`

Error output printed:
```
Started PATCH "/tasks/3/in_progress" for 127.0.0.1 at 2018-03-10 13:31:56 +0800
Processing by TasksController#in_progress as */*
  Parameters: {"id"=>"3"}
  User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1  ORDER BY "users"."id" ASC LIMIT 1  [["id", 51]] ...
 
Completed 500 Internal Server Error in 19ms (ActiveRecord: 0.6ms)

NameError (undefined local variable or method `user' for #<TasksController:0x007fbb2a4bb5f8>):
  app/controllers/tasks_controller.rb:38:in `in_progress'
```

Fix: `user` is removed from the methods because they are checked in task_policy.
Not sure if this is appropriate. Thanks!