### PR TITLE
Fix production url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MetPlus is a non-profit that aim to help the people of Detroit, and hopefully Mi
 Public Employment Tracking System – P.E.T.S.
 --------------------------------------------
 
-[www.petsworkforce.com](www.petsworkforce.com)
+[www.petsworkforce.com](http://www.petsworkforce.com)
 
 <a href="https://github.com/AgileVentures/MetPlus_PETS/wiki/Project-Overview">Project Overview</a><br>
 The PETS system is a web platform where the Job Seekers and the Companies can find each other. The platform will try to match all the skills of the Job Seekers and the skills needed by the Companies creating a pool of possible Jobs or Candidates...<a href="https://github.com/AgileVentures/MetPlus_PETS/wiki/Project-Overview">Read more</a>


### PR DESCRIPTION
Need to add the `http://` to the url link:`[](url)`
 
Otherwise, it links to: `https://github.com/AgileVentures/MetPlus_PETS/blob/development/www.petsworkforce.com`
 
![404-Page not found](https://dl.dropbox.com/s/0l0b4dxyci3n1c0/Screenshot%202018-05-17%2011.44.22.png)