### PR TITLE
Rake task to synchronize jobs from PETS to the cruncher

### DIFF
--- a/app/interactors/jobs/query.rb
+++ b/app/interactors/jobs/query.rb
@@ -1,0 +1,7 @@
+module Jobs
+  class Query
+    def all
+      Job.all
+    end
+  end
+end

--- a/app/interactors/jobs/synchronize_cruncher.rb
+++ b/app/interactors/jobs/synchronize_cruncher.rb
@@ -1,0 +1,16 @@
+module Jobs
+  class SynchronizeCruncher
+    attr_accessor :job_query, :job_cruncher
+    def initialize(job_query = nil, job_cruncher = nil)
+      @job_query = job_query || Jobs::Query.new
+      @job_cruncher = job_cruncher || JobCruncher
+    end
+
+    def call
+      job_query.all.each do |job|
+        next if job_cruncher.update_job(job.id, job.title, job.description)
+        job_cruncher.create_job(job.id, job.title, job.description)
+      end
+    end
+  end
+end

--- a/lib/tasks/jobs/synchronize.rake
+++ b/lib/tasks/jobs/synchronize.rake
@@ -1,0 +1,6 @@
+namespace :jobs do
+  desc 'Synchronize jobs from the application database to the cruncher'
+  task synchronize: :environment do
+    Jobs::SynchronizeCruncher.new.call
+  end
+end

--- a/spec/interactors/jobs/synchronize_cruncher_spec.rb
+++ b/spec/interactors/jobs/synchronize_cruncher_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Jobs::SynchronizeCruncher do
+  describe '#call' do
+    let(:job_query_double) { instance_double(Jobs::Query) }
+    let(:job_cruncher_service_double) { class_double(JobCruncher) }
+    let(:subject) { Jobs::SynchronizeCruncher.new }
+    before(:each) do
+      subject.job_query = job_query_double
+      subject.job_cruncher = job_cruncher_service_double
+    end
+
+    context 'When no jobs exist in the database' do
+      before(:each) do
+        allow(job_query_double).to receive(:all).and_return([])
+      end
+
+      it 'never try to save' do
+        expect(job_cruncher_service_double).not_to receive(:create_job)
+        expect(job_cruncher_service_double).not_to receive(:update_job)
+        subject.call
+      end
+    end
+
+    context 'When Jobs exist on the database' do
+      context 'When all jobs exist in the cruncher' do
+        before(:each) do
+          expect(job_query_double).to receive(:all).and_return(
+            [
+              Job.new(id: 1, title: 'some title', description: 'some description'),
+              Job.new(id: 2, title: 'some other title',
+                      description: 'some other description')
+            ]
+          )
+        end
+
+        it 'should be called twice' do
+          expect(job_cruncher_service_double).to receive(:update_job)
+            .twice.and_return(true, true)
+          expect(job_cruncher_service_double).not_to receive(:create_job)
+          subject.call
+        end
+      end
+
+      context 'When a job does not exist in the cruncher' do
+        before(:each) do
+          expect(job_query_double).to receive(:all).and_return(
+            [
+              Job.new(id: 1, title: 'some title', description: 'some description'),
+              Job.new(id: 2, title: 'some other title',
+                      description: 'some other description')
+            ]
+          )
+        end
+
+        it 'should be called twice' do
+          expect(job_cruncher_service_double).to receive(:update_job)
+            .twice.and_return(true, false)
+          expect(job_cruncher_service_double).to receive(:create_job)
+            .once.with(2, 'some other title', 'some other description')
+
+          subject.call
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch creates a Rake task that will update the jobs on the cruncher and if they do not exist creates them

Closes AgileVentures/MetPlus_tracker#696
Closes AgileVentures/MetPlus_tracker#718