### PR TITLE
Add a better validation for year of birth

### DIFF
--- a/app/validators/year_of_birth_validator.rb
+++ b/app/validators/year_of_birth_validator.rb
@@ -1,11 +1,11 @@
 class YearOfBirthValidator < ActiveModel::EachValidator
-
   def validate_each(object, attribute, value)
-    return if value == nil
+    return if value.nil?
     reg = /\A\d{4}\z/
 
-    if !value=~reg || !((100.years.ago.year..Date.today.year - 16).member?(value.to_i))
-        object.errors[attribute] << (options[:message] || 'age need to be between 16 and 100')
+    if !value =~ reg || !(100.years.ago.year..Date.today.year - 16).member?(value.to_i)
+      object.errors[attribute] << (options[:message] ||
+        'age need to be between 16 and 100')
     end
   end
 end

--- a/app/validators/year_of_birth_validator.rb
+++ b/app/validators/year_of_birth_validator.rb
@@ -3,9 +3,9 @@ class YearOfBirthValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     return if value == nil
     reg = /\A\d{4}\z/
-  
-    if !value=~reg  || !((100.years.ago.year..Date.today.year).member?(value.to_i))
-        object.errors[attribute] << (options[:message] || 'incorrect format')
+
+    if !value=~reg || !((100.years.ago.year..Date.today.year - 16).member?(value.to_i))
+        object.errors[attribute] << (options[:message] || 'age need to be between 16 and 100')
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -315,7 +315,7 @@ if Rails.env.development? || Rails.env.staging? || ENV['HEROKU_ENV'] == 'STAGING
     last_name = FFaker::Name.last_name
     phone = "(#{(1..9).to_a.sample(3).join})-#{(1..9).to_a.sample(3)
       .join}-#{(1..9).to_a.sample(4).join}"
-    year_of_birth = 2016 - r.rand(100)
+    year_of_birth = Date.today.year - r.rand(16..65)
     job_seeker_status = jobseekerstatus[r.rand(3)]
 
     job_seeker = JobSeeker.create(first_name: first_name,

--- a/spec/models/job_seeker_spec.rb
+++ b/spec/models/job_seeker_spec.rb
@@ -28,7 +28,9 @@ describe JobSeeker, type: :model do
     it { is_expected.to belong_to(:job_seeker_status) }
 
     it { should allow_value('1987', Date.today.year - 16).for(:year_of_birth) }
-    it { should_not allow_value('1911', '899', '1890', 'salem', '2017').for(:year_of_birth) }
+    it do
+      should_not allow_value('1911', '899', '1890', 'salem', '2017').for(:year_of_birth)
+    end
     describe 'dependent: :destroy' do
       let(:js) { FactoryBot.create(:job_seeker) }
       let(:resume) { FactoryBot.create(:resume, job_seeker: js) }

--- a/spec/models/job_seeker_spec.rb
+++ b/spec/models/job_seeker_spec.rb
@@ -27,8 +27,8 @@ describe JobSeeker, type: :model do
     it { is_expected.to have_one(:address).dependent(:destroy) }
     it { is_expected.to belong_to(:job_seeker_status) }
 
-    it { should allow_value('1987', '2000', '2014').for(:year_of_birth) }
-    it { should_not allow_value('1911', '899', '1890', 'salem').for(:year_of_birth) }
+    it { should allow_value('1987', Date.today.year - 16).for(:year_of_birth) }
+    it { should_not allow_value('1911', '899', '1890', 'salem', '2017').for(:year_of_birth) }
     describe 'dependent: :destroy' do
       let(:js) { FactoryBot.create(:job_seeker) }
       let(:resume) { FactoryBot.create(:resume, job_seeker: js) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,4 +147,6 @@ RSpec.configure do |config|
   config.include(EmailSpec::Matchers)
 
   config.pattern = '**/*_spec.rb'
+
+  config.include ValidatorHelper, :include_validator_helpers
 end

--- a/spec/validators/year_of_birth_validator_spec.rb
+++ b/spec/validators/year_of_birth_validator_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'support/validator_helper'
+include ValidatorHelper
+
+RSpec.describe YearOfBirthValidator do
+  let(:model) { ValidatorHelper.test_model_class }
+  let(:record) { model.new }
+
+  before(:each) do
+    record.class_eval do
+      validates :test_attr, year_of_birth: true
+    end
+  end
+
+  it 'adds an error when the age is more than 100 years' do
+    record.test_attr = 100.years.ago.year - 1.day
+    expect do
+      record.valid?
+    end.to change(record.errors, :messages).from({}).to a_hash_including(
+      test_attr: ['age need to be between 16 and 100']
+    )
+  end
+
+  it 'adds an error when the age is less than 16 years' do
+    record.test_attr = 15.years.ago.year
+    expect do
+      record.valid?
+    end.to change(record.errors, :messages).from({}).to a_hash_including(
+      test_attr: ['age need to be between 16 and 100']
+    )
+  end
+
+  it 'adds an error when the age is in the future' do
+    record.test_attr = Date.today.year + 1.day
+    expect do
+      record.valid?
+    end.to change(record.errors, :messages).from({}).to a_hash_including(
+      test_attr: ['age need to be between 16 and 100']
+    )
+  end
+
+  it 'does not add an error when is exactly 100 years' do
+    record.test_attr = 100.years.ago.year
+    expect do
+      record.valid?
+    end.not_to change(record.errors.messages, :count).from(0)
+  end
+end

--- a/spec/validators/year_of_birth_validator_spec.rb
+++ b/spec/validators/year_of_birth_validator_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 require 'support/validator_helper'
-include ValidatorHelper
 
-RSpec.describe YearOfBirthValidator do
-  let(:model) { ValidatorHelper.test_model_class }
+RSpec.describe YearOfBirthValidator, :include_validator_helpers do
+  let(:model) { test_model_class }
   let(:record) { model.new }
 
   before(:each) do


### PR DESCRIPTION
In the previous code the error message was to generic, it was updated to
specify the year range that is valid.
Corrected the seeds file that generated random numbers between 0-100
starting on 2016, now uses the current year as a base for the calculation
and generates number between 16-65

Fixes AgileVentures/MetPlus_tracker#721