### PR TITLE
Create dynamic menu name

### DIFF
--- a/app/controllers/agencies_controller.rb
+++ b/app/controllers/agencies_controller.rb
@@ -24,7 +24,7 @@ class AgenciesController < ApplicationController
   private
 
   def agency_params
-    params.require(:agency).permit(:name, :website, :phone, :fax,
+    params.require(:agency).permit(:name, :display_name, :website, :phone, :fax,
                                    :email, :description)
   end
 

--- a/app/helpers/agencies_helper.rb
+++ b/app/helpers/agencies_helper.rb
@@ -1,2 +1,9 @@
 module AgenciesHelper
+  def agency_display_name
+    unless current_agency.display_name.blank?
+      current_agency.display_name
+    else
+      current_agency.name
+    end
+  end
 end

--- a/app/helpers/agencies_helper.rb
+++ b/app/helpers/agencies_helper.rb
@@ -1,9 +1,9 @@
 module AgenciesHelper
   def agency_display_name
-    unless current_agency.display_name.blank?
-      current_agency.display_name
-    else
+    if current_agency.display_name.blank?
       current_agency.name
+    else
+      current_agency.display_name
     end
   end
 end

--- a/app/views/agencies/_form.html.haml
+++ b/app/views/agencies/_form.html.haml
@@ -9,6 +9,11 @@
       = text_field :agency, :name, size: 30, class: 'form-control'
 
   .form-group
+    = label :agency, :display_name, 'Display name', class: 'control-label col-sm-2'
+    .col-sm-6
+      = text_field :agency, :display_name, size: 30, class: 'form-control'
+
+  .form-group
     = label :agency, :website, 'Website', class: 'control-label col-sm-2'
     .col-sm-6
       = text_field :agency, :website, size: 30, class: 'form-control'

--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -1,7 +1,7 @@
 %nav{:class => 'menu navbar navbar-default navbar-fixed-top', data: {spy: "scroll"}}
   %div{:class => 'container'}
     %div{:class => 'navbar-header' }
-      =link_to current_agency.display_name, root_path ,{class: 'navbar-brand'}
+      =link_to agency_display_name, root_path, {class: 'navbar-brand'}
     %div{:id=>'navbar', :class => 'navbar-collapse collapse'}
       %ul{:class => 'nav navbar-nav'}
         - if user_signed_in?

--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -1,7 +1,7 @@
 %nav{:class => 'menu navbar navbar-default navbar-fixed-top', data: {spy: "scroll"}}
   %div{:class => 'container'}
     %div{:class => 'navbar-header' }
-      =link_to 'MET|PLUS', root_path ,{class: 'navbar-brand'}
+      =link_to current_agency.display_name, root_path ,{class: 'navbar-brand'}
     %div{:id=>'navbar', :class => 'navbar-collapse collapse'}
       %ul{:class => 'nav navbar-nav'}
         - if user_signed_in?

--- a/db/migrate/20180918004636_add_display_name_to_agency.rb
+++ b/db/migrate/20180918004636_add_display_name_to_agency.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToAgency < ActiveRecord::Migration
+  def change
+    add_column :agencies, :display_name, :string
+  end
+end

--- a/features/agency_admin.feature
+++ b/features/agency_admin.feature
@@ -76,7 +76,7 @@ Scenario: edit agency information
   And I click the "Agency and Partner Companies" link
   Then "pets_admin@metplus.org" should be visible
   Then I click the "Edit Agency" button
-  Then I should see "MetPlus"
+  Then I should see "METPLUS"
   And I fill in "Name" with "MetPlus Two"
   And I click "Update Agency" button
   Then I should see "Agency was successfully updated."

--- a/features/multiple_agency.feature
+++ b/features/multiple_agency.feature
@@ -1,0 +1,23 @@
+Feature: Support multiple agencies
+
+  As a PETS administrator
+  I want to support multiple agencies
+  So that the application can be more widely used
+
+  Background:
+    Given the default settings are present
+    Given the following agency people exist:
+      | agency   | role  | first_name | last_name | email            | password  | phone        |
+      | MetPlus  | AA    | John       | Smith     | aa@metplus.org   | qwerty123 | 555-222-3334 |
+    Given I am logged in as agency admin
+
+  Scenario: The agencies display name should appear on the menu
+    When I am on the home page
+    Then I should see "METPLUS"
+
+  Scenario: Updated display name should appear on the menu
+    When I go to the agency 'MetPlus' edit page
+    And I fill in "Display name" with "METS|PLUS &#x1f680;"
+    And I click "Update Agency" button
+    Then I am on the home page
+    And I should see "METS|PLUS &#x1f680;"

--- a/features/multiple_agency.feature
+++ b/features/multiple_agency.feature
@@ -21,3 +21,10 @@ Feature: Support multiple agencies
     And I click "Update Agency" button
     Then I am on the home page
     And I should see "METS|PLUS &#x1f680;"
+
+  Scenario: Displays Agency name when display name is blank
+    When I go to the agency 'MetPlus' edit page
+    And I fill in "Display name" with ""
+    And I click "Update Agency" button
+    Then I am on the home page
+    And I should see "MetPlus"

--- a/features/pages.feature
+++ b/features/pages.feature
@@ -2,7 +2,10 @@ Feature: a user clicking contact is verified by a recaptcha
 
   As prospective user of PETS
   I want to make contact and send a message
-  
+
+Background:
+  Given the default settings are present
+
 @selenium
 Scenario: make contact and check the recaptcha
   Given I am on the home page

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -253,8 +253,8 @@ Given(/^the default settings are present$/) do
     | JD    |
   ))
   step 'the following agencies exist:', table(%(
-  | name    | website     | phone        | email                  | fax          |
-  | MetPlus | metplus.org | 555-111-2222 | pets_admin@metplus.org | 617-555-1212 |
+  | name    | website     | phone        | email                  | fax          | display_name |
+  | MetPlus | metplus.org | 555-111-2222 | pets_admin@metplus.org | 617-555-1212 | METPLUS      |
   ))
   step 'the following company roles exist:', table(%(
     | role  |


### PR DESCRIPTION
Tests the agency name is displayed for the corresponding agency.

Migrated column display_name to Agency. This allows the agency to have a
display name that differs from the registered name.

Added the display name column to the feature step for creating agencies.

Added display name to the web form and whitelisted the display name.

Display the agencies display name in the menu via current_agency method.

Updated existing tests to use agency display name.

Fixes AgileVentures/MetPlus_tracker#713
Fixes AgileVentures/MetPlus_tracker#714