### PR TITLE
Display current agency in the title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
   end
 
   def full_title(page_title = '')
-    base_title = 'MetPlus'
+    base_title = current_agency.name
     page_title.empty? ? base_title : "#{page_title} | #{base_title}"
   end
 

--- a/features/multiple_agency.feature
+++ b/features/multiple_agency.feature
@@ -28,3 +28,8 @@ Feature: Support multiple agencies
     And I click "Update Agency" button
     Then I am on the home page
     And I should see "MetPlus"
+
+  Scenario: Agency name is displayed in the page title
+    When I am on the home page
+    Then I should see "MetPlus" in the title
+

--- a/features/step_definitions/multi_agency_steps.rb
+++ b/features/step_definitions/multi_agency_steps.rb
@@ -1,0 +1,3 @@
+Then(/^I should see "(.*?)" in the title$/) do |title|
+  expect(page).to have_title(title)
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   context '#full_title' do
+    metplus_agency = FactoryBot.build(:agency, name: 'MetPlus')
+    ApplicationHelper.class_eval do
+      define_method :current_agency do
+        metplus_agency
+      end
+    end
     it 'base title' do
       expect(helper.full_title).to eq('MetPlus')
     end


### PR DESCRIPTION
Test added to check agency name appears in the title with the associated
step definition. Updated the page title to display the current agencies
name.

This is done to support multiple agencies.

Fixes AgileVentures/MetPlus_tracker#712