### PR TITLE
run rubocop to fix statically defined attributes warning, fixes #703

### DIFF
--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :address do
     location { |a| a.association(:company) }
-    street '3940 Main Street'
-    city 'Detroit'
-    zipcode '92105'
-    state 'Michigan'
+    street { '3940 Main Street' }
+    city { 'Detroit' }
+    zipcode { '92105' }
+    state { 'Michigan' }
   end
 end

--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :agency do
-    name 'My Agency'
-    website 'myagency.com'
-    phone '555-111-2222'
-    email 'myagency@mail.com'
+    name { 'My Agency' }
+    website { 'myagency.com' }
+    phone { '555-111-2222' }
+    email { 'myagency@mail.com' }
   end
 end

--- a/spec/factories/agency_people.rb
+++ b/spec/factories/agency_people.rb
@@ -3,14 +3,14 @@ FactoryBot.define do
     agency
     branch
     user
-    status 'active'
+    status { 'active' }
   end
 
   factory :agency_admin, class: AgencyPerson do
     agency
     branch
     user
-    status 'active'
+    status { 'active' }
     agency_roles do
       [
         AgencyRole.find_by_role(AgencyRole::ROLE[:AA]) ||
@@ -23,7 +23,7 @@ FactoryBot.define do
     agency
     branch
     user
-    status 'active'
+    status { 'active' }
     agency_roles do
       [
         AgencyRole.find_by_role(AgencyRole::ROLE[:JD]) ||
@@ -36,7 +36,7 @@ FactoryBot.define do
     agency
     branch
     user
-    status 'active'
+    status { 'active' }
     agency_roles do
       [
         AgencyRole.find_by_role(AgencyRole::ROLE[:CM]) ||
@@ -49,7 +49,7 @@ FactoryBot.define do
     agency
     branch
     user
-    status 'active'
+    status { 'active' }
     agency_roles do
       [
         AgencyRole.find_by_role(AgencyRole::ROLE[:CM]) ||

--- a/spec/factories/agency_roles.rb
+++ b/spec/factories/agency_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :agency_role do
-    role AgencyRole::ROLE[:JD]
+    role { AgencyRole::ROLE[:JD] }
   end
 end

--- a/spec/factories/application_questions.rb
+++ b/spec/factories/application_questions.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :application_question do
     job_application
     question
-    answer false
+    answer { false }
   end
 end

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -5,14 +5,14 @@ FactoryBot.define do
   end
 
   factory :company do
-    name 'Widgets, Inc.'
+    name { 'Widgets, Inc.' }
     ein
-    phone  '123 123 1234'
-    fax    '321 321 4321'
-    email 'contact@ymail.com'
-    job_email 'jobs@ymail.com'
-    website 'http://www.widgets-r-us.com'
-    status  'active'
+    phone  { '123 123 1234' }
+    fax    { '321 321 4321' }
+    email { 'contact@ymail.com' }
+    job_email { 'jobs@ymail.com' }
+    website { 'http://www.widgets-r-us.com' }
+    status  { 'active' }
     agencies { [FactoryBot.create(:agency)] }
   end
 end

--- a/spec/factories/company_people.rb
+++ b/spec/factories/company_people.rb
@@ -3,16 +3,16 @@ FactoryBot.define do
     company
     address
     user
-    title 'Manager'
-    status 'active'
+    title { 'Manager' }
+    status { 'active' }
   end
 
   factory :first_company_admin, class: CompanyPerson do
     company
     address
     user
-    title 'Admin'
-    status 'active'
+    title { 'Admin' }
+    status { 'active' }
     company_roles do
       [CompanyRole.find_by_role(CompanyRole::ROLE[:CC]) ||
         FactoryBot.create(:company_role, role: CompanyRole::ROLE[:CC]),
@@ -25,9 +25,9 @@ FactoryBot.define do
     company
     address
     user
-    title 'Admin'
-    status 'company_pending'
-    approved false
+    title { 'Admin' }
+    status { 'company_pending' }
+    approved { false }
     company_roles do
       [CompanyRole.find_by_role(CompanyRole::ROLE[:CC]) ||
         FactoryBot.create(:company_role, role: CompanyRole::ROLE[:CC]),
@@ -40,8 +40,8 @@ FactoryBot.define do
     company
     address
     user
-    title 'Admin'
-    status 'active'
+    title { 'Admin' }
+    status { 'active' }
     company_roles do
       [CompanyRole.find_by_role(CompanyRole::ROLE[:CA]) ||
         FactoryBot.create(:company_role, role: CompanyRole::ROLE[:CA])]
@@ -52,8 +52,8 @@ FactoryBot.define do
     company
     address
     user
-    title 'Contact'
-    status 'active'
+    title { 'Contact' }
+    status { 'active' }
     company_roles do
       [CompanyRole.find_by_role(CompanyRole::ROLE[:CC]) ||
         FactoryBot.create(:company_role, role: CompanyRole::ROLE[:CC])]

--- a/spec/factories/company_roles.rb
+++ b/spec/factories/company_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :company_role do
-    role CompanyRole::ROLE[:CC]
+    role { CompanyRole::ROLE[:CC] }
   end
 end

--- a/spec/factories/educations.rb
+++ b/spec/factories/educations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :education do
-    level 'High School'
-    rank 1
+    level { 'High School' }
+    rank { 1 }
   end
 end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -1,19 +1,19 @@
 FactoryBot.define do
   factory :job_application do
-    job_seeker nil
+    job_seeker { nil }
     job
-    status :active
+    status { :active }
   end
 
   factory :not_accepted_job_application, class: JobApplication do
-    job_seeker nil
+    job_seeker { nil }
     job
-    status :not_accepted
+    status { :not_accepted }
   end
 
   factory :processing_job_application do
-    job_seeker nil
+    job_seeker { nil }
     job
-    status :processing
+    status { :processing }
   end
 end

--- a/spec/factories/job_categories.rb
+++ b/spec/factories/job_categories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :job_category do
-    name 'Software Engineer - RoR'
-    description 'Develop/maintain websites using Ruby on Rails'
+    name { 'Software Engineer - RoR' }
+    description { 'Develop/maintain websites using Ruby on Rails' }
   end
 end

--- a/spec/factories/job_questions.rb
+++ b/spec/factories/job_questions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :job_question do
-    job nil
-    question nil
+    job { nil }
+    question { nil }
   end
 end

--- a/spec/factories/job_seeker_statuses.rb
+++ b/spec/factories/job_seeker_statuses.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :job_seeker_status do
-    short_description 'Unemployed Seeking'
-    description 'Currently employed but looking for better opportunity'
+    short_description { 'Unemployed Seeking' }
+    description { 'Currently employed but looking for better opportunity' }
   end
 end

--- a/spec/factories/job_seekers.rb
+++ b/spec/factories/job_seekers.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :job_seeker do
-    year_of_birth '1998'
+    year_of_birth { '1998' }
     job_seeker_status
     association :address, factory: :address
     user
   end
   factory :job_seeker_applicant, class: JobSeeker do
-    year_of_birth '1998'
+    year_of_birth { '1998' }
     job_seeker_status
     association :address, factory: :address
     association :user, factory: :user_applicant

--- a/spec/factories/job_shifts.rb
+++ b/spec/factories/job_shifts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :job_shift do
-    shift 'Morning'
+    shift { 'Morning' }
   end
 end

--- a/spec/factories/job_skills.rb
+++ b/spec/factories/job_skills.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :job_skill do
     job
     skill
-    required false
-    min_years 1
-    max_years 1
+    required { false }
+    min_years { 1 }
+    max_years { 1 }
   end
 end

--- a/spec/factories/job_types.rb
+++ b/spec/factories/job_types.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :job_type do
-    job_type 'Full Time'
+    job_type { 'Full Time' }
   end
 end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :job do
-    title 'MyString'
-    description 'MyString'
+    title { 'MyString' }
+    description { 'MyString' }
     company
     company_person { FactoryBot.create(:company_person, company: company) }
     address
-    company_job_id 'KRKE12'
-    status :active
-    available_positions 1
-    remaining_positions 1
+    company_job_id { 'KRKE12' }
+    status { :active }
+    available_positions { 1 }
+    remaining_positions { 1 }
   end
 end

--- a/spec/factories/licenses.rb
+++ b/spec/factories/licenses.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :license do
-    abbr 'ABCD'
-    title 'Ambassador Basic Certificate of Diplomacy'
+    abbr { 'ABCD' }
+    title { 'Ambassador Basic Certificate of Diplomacy' }
   end
 end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :question do
-    question_text 'MyString'
+    question_text { 'MyString' }
   end
 end

--- a/spec/factories/resumes.rb
+++ b/spec/factories/resumes.rb
@@ -2,7 +2,7 @@ include ActionDispatch::TestProcess
 
 FactoryBot.define do
   factory :resume do
-    file_name 'Janitor-Resume.doc'
+    file_name { 'Janitor-Resume.doc' }
     job_seeker
     file { File.new("#{Rails.root}/spec/fixtures/files/Janitor-Resume.doc") }
   end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :skill do
-    name 'Software Development - RoR'
-    description 'Ruby on Rails development expertise'
+    name { 'Software Development - RoR' }
+    description { 'Ruby on Rails development expertise' }
   end
 end

--- a/spec/factories/status_changes.rb
+++ b/spec/factories/status_changes.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :status_change do
-    status_change_to 0
-    status_change_from 1
-    entity nil
+    status_change_to { 0 }
+    status_change_from { 1 }
+    entity { nil }
   end
 end

--- a/spec/factories/task_settings.rb
+++ b/spec/factories/task_settings.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :task_setting do
-    short_name 'MyString'
-    description 'MyString'
-    display_in 1
+    short_name { 'MyString' }
+    description { 'MyString' }
+    display_in { 1 }
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :task do
-    task_type 'new_task'
+    task_type { 'new_task' }
     association :owner, factory: :job_seeker, strategy: :build
-    owner_agency_role ''
-    owner_company_role ''
-    deferred_date '2016-03-29 15:37:07'
-    status Task::STATUS[:NEW]
+    owner_agency_role { '' }
+    owner_company_role { '' }
+    deferred_date { '2016-03-29 15:37:07' }
+    status { Task::STATUS[:NEW] }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,20 +3,20 @@ FactoryBot.define do
     "unique#{n}@gmail.com"
   end
   factory :user do
-    first_name 'John'
-    last_name 'Doe'
-    phone '(123) 123 1234'
+    first_name { 'John' }
+    last_name { 'Doe' }
+    phone { '(123) 123 1234' }
     email
-    password 'qwerty123'
-    password_confirmation 'qwerty123'
-    confirmed_at Time.now
+    password { 'qwerty123' }
+    password_confirmation { 'qwerty123' }
+    confirmed_at { Time.now }
   end
   factory :user_applicant, class: User do
-    first_name 'John'
-    last_name 'Doe'
-    phone '(123) 123 1234'
+    first_name { 'John' }
+    last_name { 'Doe' }
+    phone { '(123) 123 1234' }
     email
-    password 'qwerty123'
-    password_confirmation 'qwerty123'
+    password { 'qwerty123' }
+    password_confirmation { 'qwerty123' }
   end
 end


### PR DESCRIPTION
fixes #703
fixed as suggested by warning by running:
```
 rubocop \       
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```
