### PR TITLE
set max-width to 100% for all input fields

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -9,7 +9,7 @@ $gold: #f2bc60;
 $light-grey: #ddd;
 
 input {
-  max-width: 100%
+  max-width: 100%;
 }
 
 .h4 {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -8,6 +8,10 @@ $grey-color: #d9d9d9;
 $gold: #f2bc60;
 $light-grey: #ddd;
 
+input {
+  max-width: 100%
+}
+
 .h4 {
   font-weight: bold;
   line-height: 3rem;


### PR DESCRIPTION
There is a bug, when the input field size parameter is set to too large value. This PR fixes it.
![jobs](https://user-images.githubusercontent.com/904179/48319971-3bad2880-e60c-11e8-9e65-1153df7dfda3.png)
