### PR TITLE
When inactive users login error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ActiveRecord::Base
       :signed_up_but_not_approved
     elsif !approved? && pets_user.try(:company_denied?)
       :not_approved
-    elsif pets_user.company&.try(:inactive?)
+    elsif pets_user.respond_to?('company') && pets_user.company&.try(:inactive?)
       :company_no_longer_active
     else
       super

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -15,4 +15,16 @@ FactoryBot.define do
     status  { 'active' }
     agencies { [FactoryBot.create(:agency)] }
   end
+
+  factory :inactive_company, class: Company do
+    name { 'The Company, Inc.' }
+    ein
+    phone  { '789 789 7890' }
+    fax    { '987 987 9870' }
+    email { 'contact@company.ymail.com' }
+    job_email { 'jobs@company.ymail.com' }
+    website { 'http://www.thecompany.com' }
+    status  { 'inactive' }
+    agencies { [FactoryBot.create(:agency)] }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -288,4 +288,56 @@ RSpec.describe User, type: :model do
       expect(user.company_admin?(company)).to be false
     end
   end
+  describe '#inactive_message' do
+    context 'as a inactive job seeker' do
+      let(:agency) { FactoryBot.create(:agency) }
+      let(:person) { FactoryBot.create(:job_seeker) }
+
+      it 'returns inactive' do
+        expect(person.inactive_message).to be :inactive
+      end
+    end
+    context 'as a inactive case manager' do
+      let(:agency) { FactoryBot.create(:agency) }
+      let(:person) { FactoryBot.create(:case_manager, agency: agency) }
+
+      it 'returns inactive' do
+        expect(person.inactive_message).to be :inactive
+      end
+    end
+    context 'as a inactive job developer' do
+      let(:agency) { FactoryBot.create(:agency) }
+      let(:person) { FactoryBot.create(:job_developer, agency: agency) }
+
+      it 'returns inactive' do
+        expect(person.inactive_message).to be :inactive
+      end
+    end
+    context 'as a company person' do
+      context 'from an inactive company' do
+        let(:company) { FactoryBot.create(:inactive_company) }
+        let(:person) { FactoryBot.create(:pending_first_company_admin, company: company) }
+        it 'returns signed_up_but_not_approved' do
+          expect(person.inactive_message).to be :signed_up_but_not_approved
+        end
+      end
+      context 'from a company that was denied access to PETS' do
+        let(:company) { FactoryBot.create(:company) }
+        let(:person) do
+          FactoryBot.create(:pending_first_company_admin,
+                            company: company, status: 'company_denied')
+        end
+        it 'returns not_approved' do
+          expect(person.inactive_message).to be :not_approved
+        end
+      end
+      context 'from a company that is no longer active' do
+        let(:company) { FactoryBot.create(:inactive_company) }
+        let(:person) { FactoryBot.create(:company_contact, company: company) }
+        it 'returns company_no_longer_active' do
+          expect(person.inactive_message).to be :company_no_longer_active
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When an inactive user that is not a company person tries to login an exception is thrown.
This commit corrects the issue and add some coverage to that part of the code

Fixes AgileVentures/MetPlus_tracker#726