### PR TITLE
IDs of jobs and resumes changed

### DIFF
--- a/app/models/job_cruncher.rb
+++ b/app/models/job_cruncher.rb
@@ -32,6 +32,6 @@ class JobCruncher
 
     match_results = CruncherService.match_jobs(resume_id)
 
-    process_match_results match_results, 'jobId'
+    process_match_results match_results, 'id'
   end
 end

--- a/app/models/resume_cruncher.rb
+++ b/app/models/resume_cruncher.rb
@@ -36,7 +36,7 @@ class ResumeCruncher
 
     match_results = CruncherService.match_resumes(job_id)
 
-    process_match_results match_results, 'resumeId'
+    process_match_results match_results, 'userId'
   end
 
   def self.match_resume_and_job(resume_id, job_id)

--- a/app/models/resume_cruncher.rb
+++ b/app/models/resume_cruncher.rb
@@ -35,8 +35,7 @@ class ResumeCruncher
     # Resume (ID) 8 matched job with a score of 4.7, resume 5 with 3.3, etc.
 
     match_results = CruncherService.match_resumes(job_id)
-
-    process_match_results match_results, 'userId'
+    process_match_results match_results, 'resumeId'
   end
 
   def self.match_resume_and_job(resume_id, job_id)

--- a/cruncher/docker-compose.yml
+++ b/cruncher/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  db:
+    image: mongo
+    ports:
+      - 27018:27017
+    environment:
+      - MONGO_INITDB_DATABASE=resumeCruncher
+    volumes:
+      # if you wish to setup additional user accounts specific per DB or with different roles you can use following entry point
+      - "$PWD/cruncher/mongo-entrypoint/:/docker-entrypoint-initdb.d/"
+  cruncher:
+    image: agileventures/metplus-cruncher:master
+    ports:
+      - "8081:8080"
+    depends_on:
+      - db
+    links:
+      - db
+    environment:
+      - PORT=8080
+      - MONGODB_URI=mongodb://cruncher_user:cruncher_password@db:27017/resumeCruncher
+      - APP_USERNAME=cruncher_user
+      - APP_PASSWORD=cruncher_password

--- a/cruncher/mongo-entrypoint/seed-data.js
+++ b/cruncher/mongo-entrypoint/seed-data.js
@@ -1,0 +1,7 @@
+db.createUser(
+   {
+     user: "cruncher_user",
+     pwd: "cruncher_password",
+     roles: [ {role: "readWrite", db: "resumeCruncher"}]
+   }
+);

--- a/features/match_jobs_to_job_seeker.feature
+++ b/features/match_jobs_to_job_seeker.feature
@@ -49,7 +49,7 @@ Scenario: Access job seeker job matching page
   Then I press the Job Match button for 'john.seeker@gmail.com'
   And I wait 5 seconds
   And I should be on the Job Seeker 'john.seeker@gmail.com' job match page
-  And I should see "2.6 / 5.0" in the same table row as "c++ developer"
+  And I should see "4.1 / 5.0" in the same table row as "c++ developer"
 
   # Job seeker has no résumé
   And I click the "Hello, Jane" link

--- a/spec/controllers/job_seekers_controller_spec.rb
+++ b/spec/controllers/job_seekers_controller_spec.rb
@@ -739,6 +739,7 @@ RSpec.describe JobSeekersController, type: :controller do
     before(:each) do
       stub_cruncher_authenticate
       stub_cruncher_job_create
+      stub_cruncher_file_upload
       sign_in jobseeker
     end
     context 'User without a resume' do

--- a/spec/support/service_stub_helpers.rb
+++ b/spec/support/service_stub_helpers.rb
@@ -9,13 +9,13 @@ module ServiceStubHelpers
       JSON.generate('resultCode' => 'SUCCESS',
                     'message' => 'Success',
                     'resumes' => { 'matcher1' =>
-                                   [{ 'userId' => '2', 'stars' => 2.0 },
-                                    { 'userId' => '7', 'stars' => 4.9 },
-                                    { 'userId' => '5', 'stars' => 3.6 }],
+                                   [{ 'resumeId' => '2', 'stars' => 2.0 },
+                                    { 'resumeId' => '7', 'stars' => 4.9 },
+                                    { 'resumeId' => '5', 'stars' => 3.6 }],
                                    'matcher2' =>
-                                   [{ 'userId' => '8', 'stars' => 1.8 },
-                                    { 'userId' => '5', 'stars' => 3.8 },
-                                    { 'userId' => '6', 'stars' => 1.7 }] })
+                                   [{ 'resumeId' => '8', 'stars' => 1.8 },
+                                    { 'resumeId' => '5', 'stars' => 3.8 },
+                                    { 'resumeId' => '6', 'stars' => 1.7 }] })
 
     JSON_MATCHED_JOBS =
       JSON.generate('resultCode' => 'SUCCESS',

--- a/spec/support/service_stub_helpers.rb
+++ b/spec/support/service_stub_helpers.rb
@@ -9,25 +9,25 @@ module ServiceStubHelpers
       JSON.generate('resultCode' => 'SUCCESS',
                     'message' => 'Success',
                     'resumes' => { 'matcher1' =>
-                                   [{ 'resumeId' => '2', 'stars' => 2.0 },
-                                    { 'resumeId' => '7', 'stars' => 4.9 },
-                                    { 'resumeId' => '5', 'stars' => 3.6 }],
+                                   [{ 'userId' => '2', 'stars' => 2.0 },
+                                    { 'userId' => '7', 'stars' => 4.9 },
+                                    { 'userId' => '5', 'stars' => 3.6 }],
                                    'matcher2' =>
-                                   [{ 'resumeId' => '8', 'stars' => 1.8 },
-                                    { 'resumeId' => '5', 'stars' => 3.8 },
-                                    { 'resumeId' => '6', 'stars' => 1.7 }] })
+                                   [{ 'userId' => '8', 'stars' => 1.8 },
+                                    { 'userId' => '5', 'stars' => 3.8 },
+                                    { 'userId' => '6', 'stars' => 1.7 }] })
 
     JSON_MATCHED_JOBS =
       JSON.generate('resultCode' => 'SUCCESS',
                     'message' => 'Success',
                     'jobs' => { 'matcher1' =>
-                                [{ 'jobId' => '2', 'stars' => 3.8 },
-                                 { 'jobId' => '3', 'stars' => 4.7 },
-                                 { 'jobId' => '6', 'stars' => 3.2 }],
+                                [{ 'id' => '2', 'stars' => 3.8 },
+                                 { 'id' => '3', 'stars' => 4.7 },
+                                 { 'id' => '6', 'stars' => 3.2 }],
                                 'matcher2' =>
-                                [{ 'jobId' => '8', 'stars' => 2.8 },
-                                 { 'jobId' => '9', 'stars' => 2.9 },
-                                 { 'jobId' => '6', 'stars' => 3.4 }] })
+                                [{ 'id' => '8', 'stars' => 2.8 },
+                                 { 'id' => '9', 'stars' => 2.9 },
+                                 { 'id' => '6', 'stars' => 3.4 }] })
 
     JSON_MATCHED_RESUME_AND_JOB =
       JSON.generate('resultCode' => 'SUCCESS',


### PR DESCRIPTION
During the rewrite of the cruncher:
 - jobs id field changed from `jobId` to `id`
 - resumes id field changed from `resumeId` to `id`
 - the canned answers were being returned in a different order
due to the lack of orderby. Correct the expected star value in the
test to ensure it is correct